### PR TITLE
fix: add missing fpdf2 dependency in CI e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Generate test PDFs
         run: |
-          pip install pypdfium2
+          pip install fpdf2 pypdfium2
           python e2e/generate-test-data.py
 
       - name: Start stack


### PR DESCRIPTION
## Summary
- The `generate-test-data.py` script imports `fpdf` (from `fpdf2`) but only `pypdfium2` was installed in the CI workflow
- Adds `fpdf2` to the `pip install` step in the E2E job

## Test plan
- [ ] CI pipeline passes on this PR (the E2E job no longer fails on `ModuleNotFoundError: No module named 'fpdf'`)

