### PR TITLE
fix: resolve CI warnings (Node.js 20 deprecation + ESLint formatting)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   backend:
     name: Backend tests

--- a/.github/workflows/docling-compat.yml
+++ b/.github/workflows/docling-compat.yml
@@ -9,6 +9,9 @@ on:
     - cron: "30 6 * * *" # Every day at 06:30 UTC
   workflow_dispatch: # Manual trigger from GitHub UI
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   compat:
     name: Test against latest Docling

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ concurrency:
   group: docs
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Build & deploy docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - "v*"
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -28,6 +28,8 @@ export default [
       'vue/max-attributes-per-line': 'off',
       'vue/singleline-html-element-content-newline': 'off',
       'vue/html-closing-bracket-spacing': 'off',
+      'vue/html-closing-bracket-newline': 'off',
+      'vue/html-indent': 'off',
       'vue/html-self-closing': 'off',
       'vue/attributes-order': 'off',
     },


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env to all 4 workflow files (`ci.yml`, `docling-compat.yml`, `docs.yml`, `release.yml`) to suppress Node.js 20 deprecation warnings
- Disable `vue/html-indent` and `vue/html-closing-bracket-newline` ESLint rules that conflict with Prettier formatting (46 warnings eliminated)

## Test plan
- [x] CI pipeline passes with zero ESLint warnings
- [x] No Node.js 20 deprecation warnings in Actions logs

Closes #122