### PR TITLE
feat(infra): OpenSearch adapter for VectorStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@
 
 # OpenSearch URL (used by docker-compose.dev.yml, auto-set to service name)
 # OPENSEARCH_URL=http://opensearch:9200
+
+# Embedding vector dimension (default: 384 for Granite Embedding 30M / all-MiniLM-L6-v2)
+# EMBEDDING_DIMENSION=384

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Soft-delete chunks: delete button with confirmation dialog, chunks hidden from UI but preserved in data
 - Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
 - `VectorStore` port (Protocol): `ensure_index`, `index_chunks`, `search_similar`, `get_chunks`, `delete_document`
+- OpenSearch adapter (`OpenSearchStore`): kNN vector search, full-text search, bulk indexing, document CRUD
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Inline chunk text editing: double-click or edit button to modify chunk text, with save/cancel and "modified" badge
 - Docker Compose dev stack (`docker-compose.dev.yml`) with OpenSearch, Dashboards, hot-reload backend and Vite frontend
 - Soft-delete chunks: delete button with confirmation dialog, chunks hidden from UI but preserved in data
+- Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Docker Compose dev stack (`docker-compose.dev.yml`) with OpenSearch, Dashboards, hot-reload backend and Vite frontend
 - Soft-delete chunks: delete button with confirmation dialog, chunks hidden from UI but preserved in data
 - Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
+- `VectorStore` port (Protocol): `ensure_index`, `index_chunks`, `search_similar`, `get_chunks`, `delete_document`
 
 ### Fixed
 

--- a/document-parser/domain/ports.py
+++ b/document-parser/domain/ports.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         ConversionOptions,
         ConversionResult,
     )
+    from domain.vector_schema import IndexedChunk, SearchResult
 
 
 class DocumentConverter(Protocol):
@@ -79,3 +80,52 @@ class AnalysisRepository(Protocol):
     async def delete(self, job_id: str) -> bool: ...
 
     async def delete_by_document(self, document_id: str) -> int: ...
+
+
+class VectorStore(Protocol):
+    """Port for vector storage and retrieval.
+
+    Implementations (OpenSearch, pgvector, Qdrant, etc.) must satisfy this
+    contract. The port uses domain types from vector_schema — no infrastructure
+    details leak into the domain.
+    """
+
+    async def ensure_index(self, index_name: str, mapping: dict) -> None:
+        """Create the index if it does not exist. No-op if it already exists."""
+        ...
+
+    async def index_chunks(self, index_name: str, chunks: list[IndexedChunk]) -> int:
+        """Bulk-index a list of chunks. Returns the number of successfully indexed chunks."""
+        ...
+
+    async def search_similar(
+        self,
+        index_name: str,
+        embedding: list[float],
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        """Find the k nearest chunks by embedding similarity.
+
+        Args:
+            index_name: Target index.
+            embedding: Query vector.
+            k: Number of results to return.
+            doc_id: If provided, restrict search to chunks from this document.
+        """
+        ...
+
+    async def get_chunks(
+        self,
+        index_name: str,
+        doc_id: str,
+        *,
+        limit: int = 1000,
+    ) -> list[SearchResult]:
+        """Retrieve all indexed chunks for a given document, ordered by chunk_index."""
+        ...
+
+    async def delete_document(self, index_name: str, doc_id: str) -> int:
+        """Delete all chunks for a document from the index. Returns count deleted."""
+        ...

--- a/document-parser/domain/ports.py
+++ b/document-parser/domain/ports.py
@@ -6,7 +6,7 @@ Infrastructure adapters (local Docling, Docling Serve, etc.) implement these.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from domain.models import AnalysisJob, Document
@@ -82,6 +82,7 @@ class AnalysisRepository(Protocol):
     async def delete_by_document(self, document_id: str) -> int: ...
 
 
+@runtime_checkable
 class VectorStore(Protocol):
     """Port for vector storage and retrieval.
 

--- a/document-parser/domain/vector_schema.py
+++ b/document-parser/domain/vector_schema.py
@@ -104,6 +104,17 @@ class IndexedChunk:
         return result
 
 
+# -- Search result -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """A chunk returned from a vector store query."""
+
+    chunk: IndexedChunk
+    score: float  # similarity score (higher = more similar)
+
+
 # -- Index mapping template ----------------------------------------------------
 
 

--- a/document-parser/domain/vector_schema.py
+++ b/document-parser/domain/vector_schema.py
@@ -1,0 +1,166 @@
+"""Vector index schema — data contract for OpenSearch ingestion and inspection.
+
+This module defines the standard metadata schema for the vector index used by
+the ingestion pipeline (0.4.0) and the inspection UI (0.5.0).
+
+Field usage by milestone:
+    ┌────────────┬────────────────────────┬───────────────────────────────┬──────────────┐
+    │ Field      │ 0.4.0 (write)          │ 0.5.0 (read)                  │ Source       │
+    ├────────────┼────────────────────────┼───────────────────────────────┼──────────────┤
+    │ content    │ Full-text search       │ Chunk panel display           │ Docling std  │
+    │ embedding  │ Indexed                │ kNN semantic search           │ Docling std  │
+    │ doc_items  │ Indexed                │ Element type filtering        │ Docling std  │
+    │ headings   │ Indexed                │ Section hierarchy display     │ Docling std  │
+    │ origin     │ Indexed                │ Document provenance           │ Docling std  │
+    │ bboxes     │ Written at ingestion   │ Chunk↔bbox highlight          │ Studio       │
+    │ page_number│ Written at ingestion   │ Split view navigation         │ Studio       │
+    │ chunk_index│ Written at ingestion   │ Chunk ordering in panel       │ Studio       │
+    │ chunk_type │ Written at ingestion   │ Metadata panel                │ Studio       │
+    │ doc_id     │ Document linking       │ Document list navigation      │ Studio       │
+    │ filename   │ "My Documents" list    │ Display                       │ Studio       │
+    └────────────┴────────────────────────┴───────────────────────────────┴──────────────┘
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# -- Value objects for a single indexed chunk ----------------------------------
+
+DEFAULT_EMBEDDING_DIMENSION = 384  # Granite Embedding 30M (sentence-transformers)
+DEFAULT_INDEX_NAME = "docling-studio-chunks"
+
+
+@dataclass(frozen=True)
+class ChunkBboxEntry:
+    """Bounding box for a chunk region on a specific page."""
+
+    page: int
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+@dataclass(frozen=True)
+class DocItemRef:
+    """Reference to a Docling DocItem (element in the document structure)."""
+
+    self_ref: str
+    label: str  # text, table, picture, list, etc.
+
+
+@dataclass(frozen=True)
+class ChunkOrigin:
+    """Provenance metadata — links a chunk back to its source document binary."""
+
+    binary_hash: str
+    filename: str
+
+
+@dataclass(frozen=True)
+class IndexedChunk:
+    """A single chunk ready to be indexed in the vector store.
+
+    This is the domain-level representation of a document in the OpenSearch index.
+    It combines Docling-standard fields (content, embedding, doc_items, headings,
+    origin) with Docling Studio enriched fields (bboxes, page_number, chunk_index,
+    chunk_type, doc_id, filename).
+    """
+
+    doc_id: str
+    filename: str
+    content: str
+    embedding: list[float]
+    chunk_index: int
+    chunk_type: str  # text, table, picture, list, etc.
+    page_number: int
+    bboxes: list[ChunkBboxEntry] = field(default_factory=list)
+    headings: list[str] = field(default_factory=list)
+    doc_items: list[DocItemRef] = field(default_factory=list)
+    origin: ChunkOrigin | None = None
+
+    def to_dict(self) -> dict:
+        """Serialize to a dict matching the OpenSearch index mapping."""
+        result: dict = {
+            "doc_id": self.doc_id,
+            "filename": self.filename,
+            "content": self.content,
+            "embedding": self.embedding,
+            "chunk_index": self.chunk_index,
+            "chunk_type": self.chunk_type,
+            "page_number": self.page_number,
+            "bboxes": [
+                {"page": b.page, "x": b.x, "y": b.y, "w": b.w, "h": b.h} for b in self.bboxes
+            ],
+            "headings": self.headings,
+            "doc_items": [{"self_ref": d.self_ref, "label": d.label} for d in self.doc_items],
+        }
+        if self.origin:
+            result["origin"] = {
+                "binary_hash": self.origin.binary_hash,
+                "filename": self.origin.filename,
+            }
+        return result
+
+
+# -- Index mapping template ----------------------------------------------------
+
+
+def build_index_mapping(embedding_dimension: int = DEFAULT_EMBEDDING_DIMENSION) -> dict:
+    """Build the OpenSearch index mapping for the chunk index.
+
+    Args:
+        embedding_dimension: Vector dimension for the knn_vector field.
+            Defaults to 384 (Granite Embedding 30M / all-MiniLM-L6-v2).
+    """
+    return {
+        "settings": {
+            "index": {
+                "knn": True,
+            },
+        },
+        "mappings": {
+            "properties": {
+                "doc_id": {"type": "keyword"},
+                "filename": {"type": "keyword"},
+                "content": {"type": "text", "analyzer": "standard"},
+                "embedding": {
+                    "type": "knn_vector",
+                    "dimension": embedding_dimension,
+                    "method": {
+                        "engine": "faiss",
+                        "name": "hnsw",
+                    },
+                },
+                "chunk_index": {"type": "integer"},
+                "chunk_type": {"type": "keyword"},
+                "page_number": {"type": "integer"},
+                "bboxes": {
+                    "type": "nested",
+                    "properties": {
+                        "page": {"type": "integer"},
+                        "x": {"type": "float"},
+                        "y": {"type": "float"},
+                        "w": {"type": "float"},
+                        "h": {"type": "float"},
+                    },
+                },
+                "headings": {"type": "text"},
+                "doc_items": {
+                    "type": "nested",
+                    "properties": {
+                        "self_ref": {"type": "keyword"},
+                        "label": {"type": "keyword"},
+                    },
+                },
+                "origin": {
+                    "type": "object",
+                    "properties": {
+                        "binary_hash": {"type": "keyword"},
+                        "filename": {"type": "keyword"},
+                    },
+                },
+            },
+        },
+    }

--- a/document-parser/infra/opensearch_store.py
+++ b/document-parser/infra/opensearch_store.py
@@ -1,0 +1,204 @@
+"""OpenSearch adapter implementing the VectorStore port.
+
+Uses the opensearch-py client for kNN vector search, full-text search,
+and document CRUD against an OpenSearch cluster.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opensearchpy import AsyncOpenSearch, NotFoundError
+
+from domain.vector_schema import (
+    ChunkBboxEntry,
+    ChunkOrigin,
+    DocItemRef,
+    IndexedChunk,
+    SearchResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _hit_to_indexed_chunk(hit: dict[str, Any]) -> IndexedChunk:
+    """Reconstruct an IndexedChunk from an OpenSearch _source document."""
+    src = hit["_source"]
+    origin_raw = src.get("origin")
+    origin = (
+        ChunkOrigin(binary_hash=origin_raw["binary_hash"], filename=origin_raw["filename"])
+        if origin_raw
+        else None
+    )
+    return IndexedChunk(
+        doc_id=src["doc_id"],
+        filename=src["filename"],
+        content=src["content"],
+        embedding=src.get("embedding", []),
+        chunk_index=src["chunk_index"],
+        chunk_type=src["chunk_type"],
+        page_number=src["page_number"],
+        bboxes=[
+            ChunkBboxEntry(page=b["page"], x=b["x"], y=b["y"], w=b["w"], h=b["h"])
+            for b in src.get("bboxes", [])
+        ],
+        headings=src.get("headings", []),
+        doc_items=[
+            DocItemRef(self_ref=d["self_ref"], label=d["label"]) for d in src.get("doc_items", [])
+        ],
+        origin=origin,
+    )
+
+
+def _hit_to_result(hit: dict[str, Any]) -> SearchResult:
+    """Convert an OpenSearch hit to a SearchResult."""
+    return SearchResult(
+        chunk=_hit_to_indexed_chunk(hit),
+        score=hit.get("_score", 0.0),
+    )
+
+
+class OpenSearchStore:
+    """Concrete VectorStore adapter backed by OpenSearch.
+
+    Satisfies the ``VectorStore`` Protocol defined in ``domain.ports``.
+
+    Args:
+        url: OpenSearch cluster URL (e.g. ``http://localhost:9200``).
+        verify_certs: Whether to verify TLS certificates.
+    """
+
+    def __init__(self, url: str, *, verify_certs: bool = False) -> None:
+        self._client = AsyncOpenSearch(
+            hosts=[url],
+            use_ssl=url.startswith("https"),
+            verify_certs=verify_certs,
+            ssl_show_warn=False,
+        )
+
+    # -- lifecycle -------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.close()
+
+    # -- VectorStore protocol methods ------------------------------------------
+
+    async def ensure_index(self, index_name: str, mapping: dict) -> None:
+        """Create the index if it does not exist. No-op if it already exists."""
+        exists = await self._client.indices.exists(index=index_name)
+        if not exists:
+            await self._client.indices.create(index=index_name, body=mapping)
+            logger.info("Created OpenSearch index '%s'", index_name)
+        else:
+            logger.debug("Index '%s' already exists — skipping creation", index_name)
+
+    async def index_chunks(self, index_name: str, chunks: list[IndexedChunk]) -> int:
+        """Bulk-index a list of chunks. Returns the number successfully indexed."""
+        if not chunks:
+            return 0
+
+        body: list[dict[str, Any]] = []
+        for chunk in chunks:
+            doc_id = f"{chunk.doc_id}_{chunk.chunk_index}"
+            body.append({"index": {"_index": index_name, "_id": doc_id}})
+            body.append(chunk.to_dict())
+
+        resp = await self._client.bulk(body=body, refresh="wait_for")
+
+        errors = sum(1 for item in resp["items"] if item["index"].get("error"))
+        indexed = len(chunks) - errors
+        if errors:
+            logger.warning("Bulk index to '%s': %d/%d failed", index_name, errors, len(chunks))
+        return indexed
+
+    async def search_similar(
+        self,
+        index_name: str,
+        embedding: list[float],
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        """kNN search for the k nearest chunks by embedding similarity."""
+        knn_query: dict[str, Any] = {
+            "knn": {
+                "embedding": {
+                    "vector": embedding,
+                    "k": k,
+                },
+            },
+        }
+        if doc_id:
+            knn_query["knn"]["embedding"]["filter"] = {
+                "term": {"doc_id": doc_id},
+            }
+
+        resp = await self._client.search(
+            index=index_name,
+            body={"size": k, "query": knn_query},
+            _source_excludes=["embedding"],
+        )
+        return [_hit_to_result(hit) for hit in resp["hits"]["hits"]]
+
+    async def get_chunks(
+        self,
+        index_name: str,
+        doc_id: str,
+        *,
+        limit: int = 1000,
+    ) -> list[SearchResult]:
+        """Retrieve all indexed chunks for a document, ordered by chunk_index."""
+        resp = await self._client.search(
+            index=index_name,
+            body={
+                "size": limit,
+                "query": {"term": {"doc_id": doc_id}},
+                "sort": [{"chunk_index": {"order": "asc"}}],
+            },
+            _source_excludes=["embedding"],
+        )
+        return [_hit_to_result(hit) for hit in resp["hits"]["hits"]]
+
+    async def delete_document(self, index_name: str, doc_id: str) -> int:
+        """Delete all chunks for a document. Returns the number deleted."""
+        try:
+            resp = await self._client.delete_by_query(
+                index=index_name,
+                body={"query": {"term": {"doc_id": doc_id}}},
+                refresh=True,
+            )
+            deleted: int = resp.get("deleted", 0)
+            return deleted
+        except NotFoundError:
+            return 0
+
+    # -- full-text search (bonus from spec) ------------------------------------
+
+    async def search_fulltext(
+        self,
+        index_name: str,
+        query_text: str,
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        """Full-text search on the content field.
+
+        This method is not part of the VectorStore protocol but is specified
+        in the issue acceptance criteria.
+        """
+        must: list[dict[str, Any]] = [{"match": {"content": query_text}}]
+        if doc_id:
+            must.append({"term": {"doc_id": doc_id}})
+
+        resp = await self._client.search(
+            index=index_name,
+            body={
+                "size": k,
+                "query": {"bool": {"must": must}},
+            },
+            _source_excludes=["embedding"],
+        )
+        return [_hit_to_result(hit) for hit in resp["hits"]["hits"]]

--- a/document-parser/infra/settings.py
+++ b/document-parser/infra/settings.py
@@ -23,6 +23,8 @@ class Settings:
     max_file_size_mb: int = 50  # upload limit in MB (0 = unlimited)
     rate_limit_rpm: int = 100  # requests per minute per IP (0 = disabled)
     batch_page_size: int = 0  # 0 = disabled, > 0 = pages per batch
+    opensearch_url: str = ""  # empty = disabled
+    embedding_dimension: int = 384  # Granite Embedding 30M / all-MiniLM-L6-v2
     upload_dir: str = "./uploads"
     db_path: str = "./data/docling_studio.db"
     cors_origins: list[str] = field(
@@ -51,6 +53,8 @@ class Settings:
             errors.append(f"rate_limit_rpm must be >= 0 (got {self.rate_limit_rpm})")
         if self.batch_page_size < 0:
             errors.append(f"batch_page_size must be >= 0 (got {self.batch_page_size})")
+        if self.embedding_dimension < 1:
+            errors.append(f"embedding_dimension must be >= 1 (got {self.embedding_dimension})")
         if self.default_table_mode not in ("accurate", "fast"):
             errors.append(
                 f"default_table_mode must be 'accurate' or 'fast' (got '{self.default_table_mode}')"
@@ -90,6 +94,8 @@ class Settings:
             max_file_size_mb=int(os.environ.get("MAX_FILE_SIZE_MB", "50")),
             rate_limit_rpm=int(os.environ.get("RATE_LIMIT_RPM", "100")),
             batch_page_size=int(os.environ.get("BATCH_PAGE_SIZE", "0")),
+            opensearch_url=os.environ.get("OPENSEARCH_URL", ""),
+            embedding_dimension=int(os.environ.get("EMBEDDING_DIMENSION", "384")),
             upload_dir=os.environ.get("UPLOAD_DIR", "./uploads"),
             db_path=os.environ.get("DB_PATH", "./data/docling_studio.db"),
             cors_origins=[o.strip() for o in cors_raw.split(",")],

--- a/document-parser/requirements.txt
+++ b/document-parser/requirements.txt
@@ -7,3 +7,4 @@ pillow>=10.0.0,<11.0.0
 aiosqlite>=0.20.0,<1.0.0
 httpx>=0.27.0,<1.0.0
 pypdfium2>=4.0.0,<5.0.0
+opensearch-py[async]>=2.6.0,<3.0.0

--- a/document-parser/tests/test_opensearch_store.py
+++ b/document-parser/tests/test_opensearch_store.py
@@ -1,0 +1,320 @@
+"""Tests for the OpenSearch adapter (infra.opensearch_store).
+
+These tests mock the AsyncOpenSearch client to validate adapter logic
+without requiring a running OpenSearch instance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.ports import VectorStore
+from domain.vector_schema import (
+    ChunkBboxEntry,
+    ChunkOrigin,
+    DocItemRef,
+    IndexedChunk,
+    SearchResult,
+    build_index_mapping,
+)
+from infra.opensearch_store import OpenSearchStore, _hit_to_indexed_chunk, _hit_to_result
+
+# -- Fixtures -----------------------------------------------------------------
+
+
+def _make_chunk(
+    doc_id: str = "doc-1",
+    chunk_index: int = 0,
+    content: str = "hello world",
+    embedding: list[float] | None = None,
+) -> IndexedChunk:
+    return IndexedChunk(
+        doc_id=doc_id,
+        filename="test.pdf",
+        content=content,
+        embedding=embedding or [0.1, 0.2, 0.3],
+        chunk_index=chunk_index,
+        chunk_type="text",
+        page_number=1,
+        bboxes=[ChunkBboxEntry(page=1, x=0.0, y=0.0, w=100.0, h=50.0)],
+        headings=["Chapter 1"],
+        doc_items=[DocItemRef(self_ref="#/texts/0", label="text")],
+        origin=ChunkOrigin(binary_hash="abc123", filename="test.pdf"),
+    )
+
+
+def _make_hit(
+    doc_id: str = "doc-1",
+    chunk_index: int = 0,
+    score: float = 0.95,
+    content: str = "hello world",
+) -> dict:
+    return {
+        "_id": f"{doc_id}_{chunk_index}",
+        "_score": score,
+        "_source": {
+            "doc_id": doc_id,
+            "filename": "test.pdf",
+            "content": content,
+            "chunk_index": chunk_index,
+            "chunk_type": "text",
+            "page_number": 1,
+            "bboxes": [{"page": 1, "x": 0.0, "y": 0.0, "w": 100.0, "h": 50.0}],
+            "headings": ["Chapter 1"],
+            "doc_items": [{"self_ref": "#/texts/0", "label": "text"}],
+            "origin": {"binary_hash": "abc123", "filename": "test.pdf"},
+        },
+    }
+
+
+@pytest.fixture
+def store() -> OpenSearchStore:
+    return OpenSearchStore("http://localhost:9200")
+
+
+@pytest.fixture
+def mock_client(store: OpenSearchStore) -> AsyncMock:
+    client = AsyncMock()
+    store._client = client
+    return client
+
+
+# -- Protocol satisfaction -----------------------------------------------------
+
+
+class TestProtocolSatisfaction:
+    def test_satisfies_vector_store_protocol(self) -> None:
+        """OpenSearchStore structurally satisfies VectorStore Protocol."""
+        store = OpenSearchStore("http://localhost:9200")
+        assert isinstance(store, VectorStore)
+
+
+# -- Hit deserialization -------------------------------------------------------
+
+
+class TestHitDeserialization:
+    def test_hit_to_indexed_chunk(self) -> None:
+        hit = _make_hit()
+        chunk = _hit_to_indexed_chunk(hit)
+        assert isinstance(chunk, IndexedChunk)
+        assert chunk.doc_id == "doc-1"
+        assert chunk.content == "hello world"
+        assert chunk.chunk_index == 0
+        assert chunk.page_number == 1
+        assert len(chunk.bboxes) == 1
+        assert chunk.bboxes[0].w == 100.0
+        assert len(chunk.doc_items) == 1
+        assert chunk.doc_items[0].label == "text"
+        assert chunk.origin is not None
+        assert chunk.origin.binary_hash == "abc123"
+
+    def test_hit_to_indexed_chunk_no_origin(self) -> None:
+        hit = _make_hit()
+        hit["_source"]["origin"] = None
+        chunk = _hit_to_indexed_chunk(hit)
+        assert chunk.origin is None
+
+    def test_hit_to_indexed_chunk_missing_optional_fields(self) -> None:
+        hit = _make_hit()
+        del hit["_source"]["bboxes"]
+        del hit["_source"]["headings"]
+        del hit["_source"]["doc_items"]
+        del hit["_source"]["origin"]
+        chunk = _hit_to_indexed_chunk(hit)
+        assert chunk.bboxes == []
+        assert chunk.headings == []
+        assert chunk.doc_items == []
+        assert chunk.origin is None
+
+    def test_hit_to_result(self) -> None:
+        hit = _make_hit(score=0.87)
+        result = _hit_to_result(hit)
+        assert isinstance(result, SearchResult)
+        assert result.score == 0.87
+        assert result.chunk.doc_id == "doc-1"
+
+
+# -- ensure_index --------------------------------------------------------------
+
+
+class TestEnsureIndex:
+    async def test_creates_index_when_not_exists(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.indices.exists.return_value = False
+        mapping = build_index_mapping()
+        await store.ensure_index("test-index", mapping)
+        mock_client.indices.create.assert_awaited_once_with(index="test-index", body=mapping)
+
+    async def test_noop_when_index_exists(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.indices.exists.return_value = True
+        await store.ensure_index("test-index", {})
+        mock_client.indices.create.assert_not_awaited()
+
+
+# -- index_chunks --------------------------------------------------------------
+
+
+class TestIndexChunks:
+    async def test_bulk_indexes_chunks(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        chunks = [_make_chunk(chunk_index=0), _make_chunk(chunk_index=1)]
+        mock_client.bulk.return_value = {
+            "errors": False,
+            "items": [
+                {"index": {"_id": "doc-1_0", "status": 201}},
+                {"index": {"_id": "doc-1_1", "status": 201}},
+            ],
+        }
+        count = await store.index_chunks("test-index", chunks)
+        assert count == 2
+        mock_client.bulk.assert_awaited_once()
+
+    async def test_returns_zero_for_empty_list(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        count = await store.index_chunks("test-index", [])
+        assert count == 0
+        mock_client.bulk.assert_not_awaited()
+
+    async def test_counts_partial_failures(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        chunks = [_make_chunk(chunk_index=0), _make_chunk(chunk_index=1)]
+        mock_client.bulk.return_value = {
+            "errors": True,
+            "items": [
+                {"index": {"_id": "doc-1_0", "status": 201}},
+                {"index": {"_id": "doc-1_1", "error": {"reason": "mapping"}}},
+            ],
+        }
+        count = await store.index_chunks("test-index", chunks)
+        assert count == 1
+
+    async def test_bulk_body_structure(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        chunk = _make_chunk(doc_id="d1", chunk_index=3)
+        mock_client.bulk.return_value = {
+            "errors": False,
+            "items": [{"index": {"_id": "d1_3", "status": 201}}],
+        }
+        await store.index_chunks("idx", [chunk])
+        call_body = mock_client.bulk.call_args[1]["body"]
+        assert call_body[0] == {"index": {"_index": "idx", "_id": "d1_3"}}
+        assert call_body[1]["doc_id"] == "d1"
+        assert call_body[1]["chunk_index"] == 3
+
+
+# -- search_similar ------------------------------------------------------------
+
+
+class TestSearchSimilar:
+    async def test_knn_search(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.search.return_value = {"hits": {"hits": [_make_hit(score=0.99)]}}
+        results = await store.search_similar("idx", [0.1, 0.2, 0.3], k=5)
+        assert len(results) == 1
+        assert results[0].score == 0.99
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["query"]["knn"]["embedding"]["vector"] == [0.1, 0.2, 0.3]
+        assert call_body["query"]["knn"]["embedding"]["k"] == 5
+
+    async def test_knn_search_with_doc_filter(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.search_similar("idx", [0.1], doc_id="doc-42")
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["query"]["knn"]["embedding"]["filter"] == {"term": {"doc_id": "doc-42"}}
+
+    async def test_knn_search_no_filter_by_default(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.search_similar("idx", [0.1])
+        call_body = mock_client.search.call_args[1]["body"]
+        assert "filter" not in call_body["query"]["knn"]["embedding"]
+
+
+# -- get_chunks ----------------------------------------------------------------
+
+
+class TestGetChunks:
+    async def test_retrieves_by_doc_id(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {
+            "hits": {"hits": [_make_hit(chunk_index=0), _make_hit(chunk_index=1)]}
+        }
+        results = await store.get_chunks("idx", "doc-1")
+        assert len(results) == 2
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["query"] == {"term": {"doc_id": "doc-1"}}
+        assert call_body["sort"] == [{"chunk_index": {"order": "asc"}}]
+
+    async def test_respects_limit(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.get_chunks("idx", "doc-1", limit=50)
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["size"] == 50
+
+
+# -- delete_document -----------------------------------------------------------
+
+
+class TestDeleteDocument:
+    async def test_deletes_by_doc_id(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.delete_by_query.return_value = {"deleted": 5}
+        count = await store.delete_document("idx", "doc-1")
+        assert count == 5
+        call_body = mock_client.delete_by_query.call_args[1]["body"]
+        assert call_body["query"] == {"term": {"doc_id": "doc-1"}}
+
+    async def test_returns_zero_on_not_found(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        from opensearchpy import NotFoundError
+
+        mock_client.delete_by_query.side_effect = NotFoundError(404, "index_not_found")
+        count = await store.delete_document("idx", "doc-1")
+        assert count == 0
+
+
+# -- search_fulltext -----------------------------------------------------------
+
+
+class TestSearchFulltext:
+    async def test_fulltext_search(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.search.return_value = {
+            "hits": {"hits": [_make_hit(content="matching text", score=1.5)]}
+        }
+        results = await store.search_fulltext("idx", "matching")
+        assert len(results) == 1
+        assert results[0].chunk.content == "matching text"
+        call_body = mock_client.search.call_args[1]["body"]
+        assert {"match": {"content": "matching"}} in call_body["query"]["bool"]["must"]
+
+    async def test_fulltext_search_with_doc_filter(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.search_fulltext("idx", "query", doc_id="doc-5")
+        call_body = mock_client.search.call_args[1]["body"]
+        must_clauses = call_body["query"]["bool"]["must"]
+        assert {"term": {"doc_id": "doc-5"}} in must_clauses
+
+
+# -- close ---------------------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_delegates_to_client(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        await store.close()
+        mock_client.close.assert_awaited_once()

--- a/document-parser/tests/test_vector_schema.py
+++ b/document-parser/tests/test_vector_schema.py
@@ -11,6 +11,7 @@ from domain.vector_schema import (
     ChunkOrigin,
     DocItemRef,
     IndexedChunk,
+    SearchResult,
     build_index_mapping,
 )
 
@@ -187,6 +188,36 @@ class TestBuildIndexMapping:
         props = mapping["mappings"]["properties"]
         for field_name in ("chunk_index", "page_number"):
             assert props[field_name]["type"] == "integer", f"{field_name} should be integer"
+
+
+class TestSearchResult:
+    def test_construction(self):
+        chunk = IndexedChunk(
+            doc_id="doc-1",
+            filename="test.pdf",
+            content="Hello",
+            embedding=[0.1] * 384,
+            chunk_index=0,
+            chunk_type="text",
+            page_number=1,
+        )
+        result = SearchResult(chunk=chunk, score=0.95)
+        assert result.chunk.content == "Hello"
+        assert result.score == 0.95
+
+    def test_frozen(self):
+        chunk = IndexedChunk(
+            doc_id="d",
+            filename="f",
+            content="c",
+            embedding=[],
+            chunk_index=0,
+            chunk_type="text",
+            page_number=1,
+        )
+        result = SearchResult(chunk=chunk, score=0.5)
+        with pytest.raises(AttributeError):
+            result.score = 0.9  # type: ignore[misc]
 
 
 class TestConstants:

--- a/document-parser/tests/test_vector_schema.py
+++ b/document-parser/tests/test_vector_schema.py
@@ -1,0 +1,197 @@
+"""Tests for vector index schema — value objects and OpenSearch mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.vector_schema import (
+    DEFAULT_EMBEDDING_DIMENSION,
+    DEFAULT_INDEX_NAME,
+    ChunkBboxEntry,
+    ChunkOrigin,
+    DocItemRef,
+    IndexedChunk,
+    build_index_mapping,
+)
+
+
+class TestChunkBboxEntry:
+    def test_construction(self):
+        bbox = ChunkBboxEntry(page=1, x=10.0, y=20.0, w=100.0, h=50.0)
+        assert bbox.page == 1
+        assert bbox.x == 10.0
+        assert bbox.w == 100.0
+
+    def test_frozen(self):
+        bbox = ChunkBboxEntry(page=1, x=0, y=0, w=10, h=10)
+        with pytest.raises(AttributeError):
+            bbox.page = 2  # type: ignore[misc]
+
+
+class TestDocItemRef:
+    def test_construction(self):
+        ref = DocItemRef(self_ref="#/texts/0", label="text")
+        assert ref.self_ref == "#/texts/0"
+        assert ref.label == "text"
+
+
+class TestChunkOrigin:
+    def test_construction(self):
+        origin = ChunkOrigin(binary_hash="abc123", filename="doc.pdf")
+        assert origin.binary_hash == "abc123"
+        assert origin.filename == "doc.pdf"
+
+
+class TestIndexedChunk:
+    def _make_chunk(self, **overrides) -> IndexedChunk:
+        defaults = {
+            "doc_id": "doc-1",
+            "filename": "test.pdf",
+            "content": "Hello world",
+            "embedding": [0.1] * 384,
+            "chunk_index": 0,
+            "chunk_type": "text",
+            "page_number": 1,
+        }
+        defaults.update(overrides)
+        return IndexedChunk(**defaults)
+
+    def test_minimal_chunk(self):
+        chunk = self._make_chunk()
+        assert chunk.doc_id == "doc-1"
+        assert chunk.content == "Hello world"
+        assert chunk.bboxes == []
+        assert chunk.headings == []
+        assert chunk.doc_items == []
+        assert chunk.origin is None
+
+    def test_full_chunk(self):
+        chunk = self._make_chunk(
+            bboxes=[ChunkBboxEntry(page=1, x=10, y=20, w=100, h=50)],
+            headings=["Chapter 1", "Section A"],
+            doc_items=[DocItemRef(self_ref="#/texts/0", label="text")],
+            origin=ChunkOrigin(binary_hash="abc", filename="test.pdf"),
+        )
+        assert len(chunk.bboxes) == 1
+        assert chunk.headings == ["Chapter 1", "Section A"]
+        assert chunk.doc_items[0].label == "text"
+        assert chunk.origin.binary_hash == "abc"
+
+    def test_to_dict_minimal(self):
+        chunk = self._make_chunk()
+        d = chunk.to_dict()
+        assert d["doc_id"] == "doc-1"
+        assert d["filename"] == "test.pdf"
+        assert d["content"] == "Hello world"
+        assert d["embedding"] == [0.1] * 384
+        assert d["chunk_index"] == 0
+        assert d["chunk_type"] == "text"
+        assert d["page_number"] == 1
+        assert d["bboxes"] == []
+        assert d["headings"] == []
+        assert d["doc_items"] == []
+        assert "origin" not in d
+
+    def test_to_dict_full(self):
+        chunk = self._make_chunk(
+            bboxes=[ChunkBboxEntry(page=1, x=10.5, y=20.0, w=100.0, h=50.0)],
+            headings=["H1"],
+            doc_items=[DocItemRef(self_ref="#/texts/0", label="text")],
+            origin=ChunkOrigin(binary_hash="abc", filename="test.pdf"),
+        )
+        d = chunk.to_dict()
+        assert d["bboxes"] == [{"page": 1, "x": 10.5, "y": 20.0, "w": 100.0, "h": 50.0}]
+        assert d["headings"] == ["H1"]
+        assert d["doc_items"] == [{"self_ref": "#/texts/0", "label": "text"}]
+        assert d["origin"] == {"binary_hash": "abc", "filename": "test.pdf"}
+
+    def test_frozen(self):
+        chunk = self._make_chunk()
+        with pytest.raises(AttributeError):
+            chunk.content = "modified"  # type: ignore[misc]
+
+
+class TestBuildIndexMapping:
+    def test_default_dimension(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        assert props["embedding"]["dimension"] == 384
+        assert props["embedding"]["type"] == "knn_vector"
+        assert props["embedding"]["method"]["engine"] == "faiss"
+        assert props["embedding"]["method"]["name"] == "hnsw"
+
+    def test_custom_dimension(self):
+        mapping = build_index_mapping(embedding_dimension=768)
+        assert mapping["mappings"]["properties"]["embedding"]["dimension"] == 768
+
+    def test_knn_enabled(self):
+        mapping = build_index_mapping()
+        assert mapping["settings"]["index"]["knn"] is True
+
+    def test_all_fields_present(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        expected_fields = {
+            "doc_id",
+            "filename",
+            "content",
+            "embedding",
+            "chunk_index",
+            "chunk_type",
+            "page_number",
+            "bboxes",
+            "headings",
+            "doc_items",
+            "origin",
+        }
+        assert set(props.keys()) == expected_fields
+
+    def test_bboxes_nested_type(self):
+        mapping = build_index_mapping()
+        bboxes = mapping["mappings"]["properties"]["bboxes"]
+        assert bboxes["type"] == "nested"
+        assert "page" in bboxes["properties"]
+        assert "x" in bboxes["properties"]
+        assert "y" in bboxes["properties"]
+        assert "w" in bboxes["properties"]
+        assert "h" in bboxes["properties"]
+
+    def test_doc_items_nested_type(self):
+        mapping = build_index_mapping()
+        doc_items = mapping["mappings"]["properties"]["doc_items"]
+        assert doc_items["type"] == "nested"
+        assert "self_ref" in doc_items["properties"]
+        assert "label" in doc_items["properties"]
+
+    def test_origin_object_type(self):
+        mapping = build_index_mapping()
+        origin = mapping["mappings"]["properties"]["origin"]
+        assert origin["type"] == "object"
+        assert "binary_hash" in origin["properties"]
+        assert "filename" in origin["properties"]
+
+    def test_content_uses_standard_analyzer(self):
+        mapping = build_index_mapping()
+        content = mapping["mappings"]["properties"]["content"]
+        assert content["type"] == "text"
+        assert content["analyzer"] == "standard"
+
+    def test_keyword_fields(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        for field_name in ("doc_id", "filename", "chunk_type"):
+            assert props[field_name]["type"] == "keyword", f"{field_name} should be keyword"
+
+    def test_integer_fields(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        for field_name in ("chunk_index", "page_number"):
+            assert props[field_name]["type"] == "integer", f"{field_name} should be integer"
+
+
+class TestConstants:
+    def test_default_embedding_dimension(self):
+        assert DEFAULT_EMBEDDING_DIMENSION == 384
+
+    def test_default_index_name(self):
+        assert DEFAULT_INDEX_NAME == "docling-studio-chunks"

--- a/document-parser/tests/test_vector_store_port.py
+++ b/document-parser/tests/test_vector_store_port.py
@@ -1,0 +1,113 @@
+"""Tests for VectorStore port — verify the protocol contract is implementable."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.ports import VectorStore
+from domain.vector_schema import IndexedChunk, SearchResult
+
+
+class FakeVectorStore:
+    """Minimal concrete implementation to verify the protocol is implementable."""
+
+    async def ensure_index(self, index_name: str, mapping: dict) -> None:
+        pass
+
+    async def index_chunks(self, index_name: str, chunks: list[IndexedChunk]) -> int:
+        return len(chunks)
+
+    async def search_similar(
+        self,
+        index_name: str,
+        embedding: list[float],
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        return []
+
+    async def get_chunks(
+        self,
+        index_name: str,
+        doc_id: str,
+        *,
+        limit: int = 1000,
+    ) -> list[SearchResult]:
+        return []
+
+    async def delete_document(self, index_name: str, doc_id: str) -> int:
+        return 0
+
+
+class TestVectorStorePort:
+    def test_fake_satisfies_protocol(self):
+        """A class implementing all methods is accepted as a VectorStore."""
+        store: VectorStore = FakeVectorStore()
+        assert store is not None
+
+    @pytest.mark.asyncio
+    async def test_ensure_index(self):
+        store = FakeVectorStore()
+        await store.ensure_index("test-index", {"mappings": {}})
+
+    @pytest.mark.asyncio
+    async def test_index_chunks(self):
+        store = FakeVectorStore()
+        chunk = IndexedChunk(
+            doc_id="d1",
+            filename="test.pdf",
+            content="Hello",
+            embedding=[0.1] * 384,
+            chunk_index=0,
+            chunk_type="text",
+            page_number=1,
+        )
+        count = await store.index_chunks("test-index", [chunk])
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_search_similar(self):
+        store = FakeVectorStore()
+        results = await store.search_similar("test-index", [0.1] * 384, k=5)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_similar_with_doc_filter(self):
+        store = FakeVectorStore()
+        results = await store.search_similar("test-index", [0.1] * 384, k=5, doc_id="d1")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_chunks(self):
+        store = FakeVectorStore()
+        results = await store.get_chunks("test-index", "d1")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_chunks_with_limit(self):
+        store = FakeVectorStore()
+        results = await store.get_chunks("test-index", "d1", limit=50)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_delete_document(self):
+        store = FakeVectorStore()
+        count = await store.delete_document("test-index", "d1")
+        assert count == 0
+
+    def test_protocol_methods_list(self):
+        """Verify the protocol exposes the expected methods."""
+        expected = {
+            "ensure_index",
+            "index_chunks",
+            "search_similar",
+            "get_chunks",
+            "delete_document",
+        }
+        protocol_methods = {
+            name
+            for name in dir(VectorStore)
+            if not name.startswith("_") and callable(getattr(VectorStore, name, None))
+        }
+        assert expected.issubset(protocol_methods)


### PR DESCRIPTION
## Summary

- Add `OpenSearchStore` adapter in `infra/opensearch_store.py` implementing the `VectorStore` Protocol
- kNN vector search with optional doc_id filter
- Full-text search on content field (`search_fulltext` bonus method)
- Bulk indexing with partial failure counting
- Document deletion via `delete_by_query`
- Index lifecycle via `ensure_index` (idempotent create)
- Add `opensearch-py[async]` dependency
- Add `@runtime_checkable` to `VectorStore` Protocol for isinstance checks

Closes #70

## Test plan

- [x] `OpenSearchStore` satisfies `VectorStore` Protocol (isinstance check)
- [x] 21 unit tests with mocked `AsyncOpenSearch` client
- [x] Hit deserialization (full, no origin, missing optional fields)
- [x] Bulk index body structure and partial failure counting
- [x] kNN query construction with/without doc filter
- [x] Full-text search with/without doc filter
- [x] 345 tests pass, zero lint/format violations