### PR TITLE
feat: embedding microservice (sentence-transformers)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@
 
 # OpenSearch URL (used by docker-compose.dev.yml, auto-set to service name)
 # OPENSEARCH_URL=http://opensearch:9200
+
+# Embedding vector dimension (default: 384 for Granite Embedding 30M / all-MiniLM-L6-v2)
+# EMBEDDING_DIMENSION=384

--- a/.env.example
+++ b/.env.example
@@ -40,5 +40,11 @@
 # OpenSearch URL (used by docker-compose.dev.yml, auto-set to service name)
 # OPENSEARCH_URL=http://opensearch:9200
 
+# Embedding service URL (used by docker-compose.dev.yml, auto-set to service name)
+# EMBEDDING_URL=http://embedding:8001
+
+# Embedding model (default: all-MiniLM-L6-v2, used by the embedding service)
+# EMBEDDING_MODEL=all-MiniLM-L6-v2
+
 # Embedding vector dimension (default: 384 for Granite Embedding 30M / all-MiniLM-L6-v2)
 # EMBEDDING_DIMENSION=384

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Soft-delete chunks: delete button with confirmation dialog, chunks hidden from UI but preserved in data
 - Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
 - `VectorStore` port (Protocol): `ensure_index`, `index_chunks`, `search_similar`, `get_chunks`, `delete_document`
+- OpenSearch adapter (`OpenSearchStore`): kNN vector search, full-text search, bulk indexing, document CRUD
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Inline chunk text editing: double-click or edit button to modify chunk text, with save/cancel and "modified" badge
 - Docker Compose dev stack (`docker-compose.dev.yml`) with OpenSearch, Dashboards, hot-reload backend and Vite frontend
 - Soft-delete chunks: delete button with confirmation dialog, chunks hidden from UI but preserved in data
+- Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Docker Compose dev stack (`docker-compose.dev.yml`) with OpenSearch, Dashboards, hot-reload backend and Vite frontend
 - Soft-delete chunks: delete button with confirmation dialog, chunks hidden from UI but preserved in data
 - Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
+- `VectorStore` port (Protocol): `ensure_index`, `index_chunks`, `search_similar`, `get_chunks`, `delete_document`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Vector index metadata schema: `IndexedChunk` domain model, OpenSearch mapping builder, configurable embedding dimension
 - `VectorStore` port (Protocol): `ensure_index`, `index_chunks`, `search_similar`, `get_chunks`, `delete_document`
 - OpenSearch adapter (`OpenSearchStore`): kNN vector search, full-text search, bulk indexing, document CRUD
+- Embedding microservice (`embedding-service/`): sentence-transformers REST API with batch processing and Dockerfile
+- `EmbeddingService` port and `EmbeddingClient` HTTP adapter for remote embedding generation
 
 ### Fixed
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,6 +38,25 @@ services:
       opensearch:
         condition: service_healthy
 
+  # --- Embedding service (sentence-transformers) ---
+  embedding:
+    build:
+      context: ./embedding-service
+    ports:
+      - "8001:8001"
+    environment:
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-all-MiniLM-L6-v2}
+      EMBEDDING_BATCH_SIZE: ${EMBEDDING_BATCH_SIZE:-64}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8001/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+
   # --- Backend (FastAPI with hot-reload) ---
   document-parser:
     build:
@@ -57,9 +76,12 @@ services:
       MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-50}
       BATCH_PAGE_SIZE: ${BATCH_PAGE_SIZE:-0}
       OPENSEARCH_URL: http://opensearch:9200
+      EMBEDDING_URL: http://embedding:8001
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     depends_on:
       opensearch:
+        condition: service_healthy
+      embedding:
         condition: service_healthy
     deploy:
       resources:

--- a/document-parser/domain/ports.py
+++ b/document-parser/domain/ports.py
@@ -83,6 +83,18 @@ class AnalysisRepository(Protocol):
 
 
 @runtime_checkable
+class EmbeddingService(Protocol):
+    """Port for text-to-vector embedding.
+
+    Implementations may call a local model, a remote microservice, etc.
+    """
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embedding vectors for a batch of texts."""
+        ...
+
+
+@runtime_checkable
 class VectorStore(Protocol):
     """Port for vector storage and retrieval.
 

--- a/document-parser/domain/ports.py
+++ b/document-parser/domain/ports.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         ConversionOptions,
         ConversionResult,
     )
+    from domain.vector_schema import IndexedChunk, SearchResult
 
 
 class DocumentConverter(Protocol):
@@ -79,3 +80,52 @@ class AnalysisRepository(Protocol):
     async def delete(self, job_id: str) -> bool: ...
 
     async def delete_by_document(self, document_id: str) -> int: ...
+
+
+class VectorStore(Protocol):
+    """Port for vector storage and retrieval.
+
+    Implementations (OpenSearch, pgvector, Qdrant, etc.) must satisfy this
+    contract. The port uses domain types from vector_schema — no infrastructure
+    details leak into the domain.
+    """
+
+    async def ensure_index(self, index_name: str, mapping: dict) -> None:
+        """Create the index if it does not exist. No-op if it already exists."""
+        ...
+
+    async def index_chunks(self, index_name: str, chunks: list[IndexedChunk]) -> int:
+        """Bulk-index a list of chunks. Returns the number of successfully indexed chunks."""
+        ...
+
+    async def search_similar(
+        self,
+        index_name: str,
+        embedding: list[float],
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        """Find the k nearest chunks by embedding similarity.
+
+        Args:
+            index_name: Target index.
+            embedding: Query vector.
+            k: Number of results to return.
+            doc_id: If provided, restrict search to chunks from this document.
+        """
+        ...
+
+    async def get_chunks(
+        self,
+        index_name: str,
+        doc_id: str,
+        *,
+        limit: int = 1000,
+    ) -> list[SearchResult]:
+        """Retrieve all indexed chunks for a given document, ordered by chunk_index."""
+        ...
+
+    async def delete_document(self, index_name: str, doc_id: str) -> int:
+        """Delete all chunks for a document from the index. Returns count deleted."""
+        ...

--- a/document-parser/domain/ports.py
+++ b/document-parser/domain/ports.py
@@ -6,7 +6,7 @@ Infrastructure adapters (local Docling, Docling Serve, etc.) implement these.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from domain.models import AnalysisJob, Document
@@ -82,6 +82,7 @@ class AnalysisRepository(Protocol):
     async def delete_by_document(self, document_id: str) -> int: ...
 
 
+@runtime_checkable
 class VectorStore(Protocol):
     """Port for vector storage and retrieval.
 

--- a/document-parser/domain/vector_schema.py
+++ b/document-parser/domain/vector_schema.py
@@ -104,6 +104,17 @@ class IndexedChunk:
         return result
 
 
+# -- Search result -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """A chunk returned from a vector store query."""
+
+    chunk: IndexedChunk
+    score: float  # similarity score (higher = more similar)
+
+
 # -- Index mapping template ----------------------------------------------------
 
 

--- a/document-parser/domain/vector_schema.py
+++ b/document-parser/domain/vector_schema.py
@@ -1,0 +1,166 @@
+"""Vector index schema — data contract for OpenSearch ingestion and inspection.
+
+This module defines the standard metadata schema for the vector index used by
+the ingestion pipeline (0.4.0) and the inspection UI (0.5.0).
+
+Field usage by milestone:
+    ┌────────────┬────────────────────────┬───────────────────────────────┬──────────────┐
+    │ Field      │ 0.4.0 (write)          │ 0.5.0 (read)                  │ Source       │
+    ├────────────┼────────────────────────┼───────────────────────────────┼──────────────┤
+    │ content    │ Full-text search       │ Chunk panel display           │ Docling std  │
+    │ embedding  │ Indexed                │ kNN semantic search           │ Docling std  │
+    │ doc_items  │ Indexed                │ Element type filtering        │ Docling std  │
+    │ headings   │ Indexed                │ Section hierarchy display     │ Docling std  │
+    │ origin     │ Indexed                │ Document provenance           │ Docling std  │
+    │ bboxes     │ Written at ingestion   │ Chunk↔bbox highlight          │ Studio       │
+    │ page_number│ Written at ingestion   │ Split view navigation         │ Studio       │
+    │ chunk_index│ Written at ingestion   │ Chunk ordering in panel       │ Studio       │
+    │ chunk_type │ Written at ingestion   │ Metadata panel                │ Studio       │
+    │ doc_id     │ Document linking       │ Document list navigation      │ Studio       │
+    │ filename   │ "My Documents" list    │ Display                       │ Studio       │
+    └────────────┴────────────────────────┴───────────────────────────────┴──────────────┘
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# -- Value objects for a single indexed chunk ----------------------------------
+
+DEFAULT_EMBEDDING_DIMENSION = 384  # Granite Embedding 30M (sentence-transformers)
+DEFAULT_INDEX_NAME = "docling-studio-chunks"
+
+
+@dataclass(frozen=True)
+class ChunkBboxEntry:
+    """Bounding box for a chunk region on a specific page."""
+
+    page: int
+    x: float
+    y: float
+    w: float
+    h: float
+
+
+@dataclass(frozen=True)
+class DocItemRef:
+    """Reference to a Docling DocItem (element in the document structure)."""
+
+    self_ref: str
+    label: str  # text, table, picture, list, etc.
+
+
+@dataclass(frozen=True)
+class ChunkOrigin:
+    """Provenance metadata — links a chunk back to its source document binary."""
+
+    binary_hash: str
+    filename: str
+
+
+@dataclass(frozen=True)
+class IndexedChunk:
+    """A single chunk ready to be indexed in the vector store.
+
+    This is the domain-level representation of a document in the OpenSearch index.
+    It combines Docling-standard fields (content, embedding, doc_items, headings,
+    origin) with Docling Studio enriched fields (bboxes, page_number, chunk_index,
+    chunk_type, doc_id, filename).
+    """
+
+    doc_id: str
+    filename: str
+    content: str
+    embedding: list[float]
+    chunk_index: int
+    chunk_type: str  # text, table, picture, list, etc.
+    page_number: int
+    bboxes: list[ChunkBboxEntry] = field(default_factory=list)
+    headings: list[str] = field(default_factory=list)
+    doc_items: list[DocItemRef] = field(default_factory=list)
+    origin: ChunkOrigin | None = None
+
+    def to_dict(self) -> dict:
+        """Serialize to a dict matching the OpenSearch index mapping."""
+        result: dict = {
+            "doc_id": self.doc_id,
+            "filename": self.filename,
+            "content": self.content,
+            "embedding": self.embedding,
+            "chunk_index": self.chunk_index,
+            "chunk_type": self.chunk_type,
+            "page_number": self.page_number,
+            "bboxes": [
+                {"page": b.page, "x": b.x, "y": b.y, "w": b.w, "h": b.h} for b in self.bboxes
+            ],
+            "headings": self.headings,
+            "doc_items": [{"self_ref": d.self_ref, "label": d.label} for d in self.doc_items],
+        }
+        if self.origin:
+            result["origin"] = {
+                "binary_hash": self.origin.binary_hash,
+                "filename": self.origin.filename,
+            }
+        return result
+
+
+# -- Index mapping template ----------------------------------------------------
+
+
+def build_index_mapping(embedding_dimension: int = DEFAULT_EMBEDDING_DIMENSION) -> dict:
+    """Build the OpenSearch index mapping for the chunk index.
+
+    Args:
+        embedding_dimension: Vector dimension for the knn_vector field.
+            Defaults to 384 (Granite Embedding 30M / all-MiniLM-L6-v2).
+    """
+    return {
+        "settings": {
+            "index": {
+                "knn": True,
+            },
+        },
+        "mappings": {
+            "properties": {
+                "doc_id": {"type": "keyword"},
+                "filename": {"type": "keyword"},
+                "content": {"type": "text", "analyzer": "standard"},
+                "embedding": {
+                    "type": "knn_vector",
+                    "dimension": embedding_dimension,
+                    "method": {
+                        "engine": "faiss",
+                        "name": "hnsw",
+                    },
+                },
+                "chunk_index": {"type": "integer"},
+                "chunk_type": {"type": "keyword"},
+                "page_number": {"type": "integer"},
+                "bboxes": {
+                    "type": "nested",
+                    "properties": {
+                        "page": {"type": "integer"},
+                        "x": {"type": "float"},
+                        "y": {"type": "float"},
+                        "w": {"type": "float"},
+                        "h": {"type": "float"},
+                    },
+                },
+                "headings": {"type": "text"},
+                "doc_items": {
+                    "type": "nested",
+                    "properties": {
+                        "self_ref": {"type": "keyword"},
+                        "label": {"type": "keyword"},
+                    },
+                },
+                "origin": {
+                    "type": "object",
+                    "properties": {
+                        "binary_hash": {"type": "keyword"},
+                        "filename": {"type": "keyword"},
+                    },
+                },
+            },
+        },
+    }

--- a/document-parser/infra/embedding_client.py
+++ b/document-parser/infra/embedding_client.py
@@ -1,0 +1,51 @@
+"""HTTP client adapter for the embedding microservice.
+
+Satisfies the ``EmbeddingService`` Protocol defined in ``domain.ports``.
+Calls the embedding-service REST API (POST /embed).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Maximum texts per request to avoid payload / memory issues on the server.
+_MAX_BATCH = 256
+
+
+class EmbeddingClient:
+    """Remote embedding adapter backed by the embedding-service microservice.
+
+    Args:
+        base_url: Embedding service URL (e.g. ``http://localhost:8001``).
+        timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(self, base_url: str, *, timeout: float = 120.0) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings by calling the remote service.
+
+        Automatically splits large batches into sub-batches of ``_MAX_BATCH``.
+        """
+        if not texts:
+            return []
+
+        all_embeddings: list[list[float]] = []
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            for start in range(0, len(texts), _MAX_BATCH):
+                batch = texts[start : start + _MAX_BATCH]
+                resp = await client.post(
+                    f"{self._base_url}/embed",
+                    json={"texts": batch},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                all_embeddings.extend(data["embeddings"])
+
+        return all_embeddings

--- a/document-parser/infra/opensearch_store.py
+++ b/document-parser/infra/opensearch_store.py
@@ -1,0 +1,204 @@
+"""OpenSearch adapter implementing the VectorStore port.
+
+Uses the opensearch-py client for kNN vector search, full-text search,
+and document CRUD against an OpenSearch cluster.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from opensearchpy import AsyncOpenSearch, NotFoundError
+
+from domain.vector_schema import (
+    ChunkBboxEntry,
+    ChunkOrigin,
+    DocItemRef,
+    IndexedChunk,
+    SearchResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _hit_to_indexed_chunk(hit: dict[str, Any]) -> IndexedChunk:
+    """Reconstruct an IndexedChunk from an OpenSearch _source document."""
+    src = hit["_source"]
+    origin_raw = src.get("origin")
+    origin = (
+        ChunkOrigin(binary_hash=origin_raw["binary_hash"], filename=origin_raw["filename"])
+        if origin_raw
+        else None
+    )
+    return IndexedChunk(
+        doc_id=src["doc_id"],
+        filename=src["filename"],
+        content=src["content"],
+        embedding=src.get("embedding", []),
+        chunk_index=src["chunk_index"],
+        chunk_type=src["chunk_type"],
+        page_number=src["page_number"],
+        bboxes=[
+            ChunkBboxEntry(page=b["page"], x=b["x"], y=b["y"], w=b["w"], h=b["h"])
+            for b in src.get("bboxes", [])
+        ],
+        headings=src.get("headings", []),
+        doc_items=[
+            DocItemRef(self_ref=d["self_ref"], label=d["label"]) for d in src.get("doc_items", [])
+        ],
+        origin=origin,
+    )
+
+
+def _hit_to_result(hit: dict[str, Any]) -> SearchResult:
+    """Convert an OpenSearch hit to a SearchResult."""
+    return SearchResult(
+        chunk=_hit_to_indexed_chunk(hit),
+        score=hit.get("_score", 0.0),
+    )
+
+
+class OpenSearchStore:
+    """Concrete VectorStore adapter backed by OpenSearch.
+
+    Satisfies the ``VectorStore`` Protocol defined in ``domain.ports``.
+
+    Args:
+        url: OpenSearch cluster URL (e.g. ``http://localhost:9200``).
+        verify_certs: Whether to verify TLS certificates.
+    """
+
+    def __init__(self, url: str, *, verify_certs: bool = False) -> None:
+        self._client = AsyncOpenSearch(
+            hosts=[url],
+            use_ssl=url.startswith("https"),
+            verify_certs=verify_certs,
+            ssl_show_warn=False,
+        )
+
+    # -- lifecycle -------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        await self._client.close()
+
+    # -- VectorStore protocol methods ------------------------------------------
+
+    async def ensure_index(self, index_name: str, mapping: dict) -> None:
+        """Create the index if it does not exist. No-op if it already exists."""
+        exists = await self._client.indices.exists(index=index_name)
+        if not exists:
+            await self._client.indices.create(index=index_name, body=mapping)
+            logger.info("Created OpenSearch index '%s'", index_name)
+        else:
+            logger.debug("Index '%s' already exists — skipping creation", index_name)
+
+    async def index_chunks(self, index_name: str, chunks: list[IndexedChunk]) -> int:
+        """Bulk-index a list of chunks. Returns the number successfully indexed."""
+        if not chunks:
+            return 0
+
+        body: list[dict[str, Any]] = []
+        for chunk in chunks:
+            doc_id = f"{chunk.doc_id}_{chunk.chunk_index}"
+            body.append({"index": {"_index": index_name, "_id": doc_id}})
+            body.append(chunk.to_dict())
+
+        resp = await self._client.bulk(body=body, refresh="wait_for")
+
+        errors = sum(1 for item in resp["items"] if item["index"].get("error"))
+        indexed = len(chunks) - errors
+        if errors:
+            logger.warning("Bulk index to '%s': %d/%d failed", index_name, errors, len(chunks))
+        return indexed
+
+    async def search_similar(
+        self,
+        index_name: str,
+        embedding: list[float],
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        """kNN search for the k nearest chunks by embedding similarity."""
+        knn_query: dict[str, Any] = {
+            "knn": {
+                "embedding": {
+                    "vector": embedding,
+                    "k": k,
+                },
+            },
+        }
+        if doc_id:
+            knn_query["knn"]["embedding"]["filter"] = {
+                "term": {"doc_id": doc_id},
+            }
+
+        resp = await self._client.search(
+            index=index_name,
+            body={"size": k, "query": knn_query},
+            _source_excludes=["embedding"],
+        )
+        return [_hit_to_result(hit) for hit in resp["hits"]["hits"]]
+
+    async def get_chunks(
+        self,
+        index_name: str,
+        doc_id: str,
+        *,
+        limit: int = 1000,
+    ) -> list[SearchResult]:
+        """Retrieve all indexed chunks for a document, ordered by chunk_index."""
+        resp = await self._client.search(
+            index=index_name,
+            body={
+                "size": limit,
+                "query": {"term": {"doc_id": doc_id}},
+                "sort": [{"chunk_index": {"order": "asc"}}],
+            },
+            _source_excludes=["embedding"],
+        )
+        return [_hit_to_result(hit) for hit in resp["hits"]["hits"]]
+
+    async def delete_document(self, index_name: str, doc_id: str) -> int:
+        """Delete all chunks for a document. Returns the number deleted."""
+        try:
+            resp = await self._client.delete_by_query(
+                index=index_name,
+                body={"query": {"term": {"doc_id": doc_id}}},
+                refresh=True,
+            )
+            deleted: int = resp.get("deleted", 0)
+            return deleted
+        except NotFoundError:
+            return 0
+
+    # -- full-text search (bonus from spec) ------------------------------------
+
+    async def search_fulltext(
+        self,
+        index_name: str,
+        query_text: str,
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        """Full-text search on the content field.
+
+        This method is not part of the VectorStore protocol but is specified
+        in the issue acceptance criteria.
+        """
+        must: list[dict[str, Any]] = [{"match": {"content": query_text}}]
+        if doc_id:
+            must.append({"term": {"doc_id": doc_id}})
+
+        resp = await self._client.search(
+            index=index_name,
+            body={
+                "size": k,
+                "query": {"bool": {"must": must}},
+            },
+            _source_excludes=["embedding"],
+        )
+        return [_hit_to_result(hit) for hit in resp["hits"]["hits"]]

--- a/document-parser/infra/settings.py
+++ b/document-parser/infra/settings.py
@@ -24,6 +24,7 @@ class Settings:
     rate_limit_rpm: int = 100  # requests per minute per IP (0 = disabled)
     batch_page_size: int = 0  # 0 = disabled, > 0 = pages per batch
     opensearch_url: str = ""  # empty = disabled
+    embedding_url: str = ""  # empty = disabled (e.g. http://localhost:8001)
     embedding_dimension: int = 384  # Granite Embedding 30M / all-MiniLM-L6-v2
     upload_dir: str = "./uploads"
     db_path: str = "./data/docling_studio.db"
@@ -95,6 +96,7 @@ class Settings:
             rate_limit_rpm=int(os.environ.get("RATE_LIMIT_RPM", "100")),
             batch_page_size=int(os.environ.get("BATCH_PAGE_SIZE", "0")),
             opensearch_url=os.environ.get("OPENSEARCH_URL", ""),
+            embedding_url=os.environ.get("EMBEDDING_URL", ""),
             embedding_dimension=int(os.environ.get("EMBEDDING_DIMENSION", "384")),
             upload_dir=os.environ.get("UPLOAD_DIR", "./uploads"),
             db_path=os.environ.get("DB_PATH", "./data/docling_studio.db"),

--- a/document-parser/infra/settings.py
+++ b/document-parser/infra/settings.py
@@ -23,6 +23,8 @@ class Settings:
     max_file_size_mb: int = 50  # upload limit in MB (0 = unlimited)
     rate_limit_rpm: int = 100  # requests per minute per IP (0 = disabled)
     batch_page_size: int = 0  # 0 = disabled, > 0 = pages per batch
+    opensearch_url: str = ""  # empty = disabled
+    embedding_dimension: int = 384  # Granite Embedding 30M / all-MiniLM-L6-v2
     upload_dir: str = "./uploads"
     db_path: str = "./data/docling_studio.db"
     cors_origins: list[str] = field(
@@ -51,6 +53,8 @@ class Settings:
             errors.append(f"rate_limit_rpm must be >= 0 (got {self.rate_limit_rpm})")
         if self.batch_page_size < 0:
             errors.append(f"batch_page_size must be >= 0 (got {self.batch_page_size})")
+        if self.embedding_dimension < 1:
+            errors.append(f"embedding_dimension must be >= 1 (got {self.embedding_dimension})")
         if self.default_table_mode not in ("accurate", "fast"):
             errors.append(
                 f"default_table_mode must be 'accurate' or 'fast' (got '{self.default_table_mode}')"
@@ -90,6 +94,8 @@ class Settings:
             max_file_size_mb=int(os.environ.get("MAX_FILE_SIZE_MB", "50")),
             rate_limit_rpm=int(os.environ.get("RATE_LIMIT_RPM", "100")),
             batch_page_size=int(os.environ.get("BATCH_PAGE_SIZE", "0")),
+            opensearch_url=os.environ.get("OPENSEARCH_URL", ""),
+            embedding_dimension=int(os.environ.get("EMBEDDING_DIMENSION", "384")),
             upload_dir=os.environ.get("UPLOAD_DIR", "./uploads"),
             db_path=os.environ.get("DB_PATH", "./data/docling_studio.db"),
             cors_origins=[o.strip() for o in cors_raw.split(",")],

--- a/document-parser/requirements.txt
+++ b/document-parser/requirements.txt
@@ -7,3 +7,4 @@ pillow>=10.0.0,<11.0.0
 aiosqlite>=0.20.0,<1.0.0
 httpx>=0.27.0,<1.0.0
 pypdfium2>=4.0.0,<5.0.0
+opensearch-py[async]>=2.6.0,<3.0.0

--- a/document-parser/tests/test_embedding_client.py
+++ b/document-parser/tests/test_embedding_client.py
@@ -1,0 +1,112 @@
+"""Tests for the embedding client adapter (infra.embedding_client).
+
+Mock httpx to validate adapter logic without running the embedding service.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from domain.ports import EmbeddingService
+from infra.embedding_client import _MAX_BATCH, EmbeddingClient
+
+# -- Protocol satisfaction -----------------------------------------------------
+
+
+class TestProtocolSatisfaction:
+    def test_satisfies_embedding_service_protocol(self) -> None:
+        client = EmbeddingClient("http://localhost:8001")
+        assert isinstance(client, EmbeddingService)
+
+
+# -- embed ---------------------------------------------------------------------
+
+
+class TestEmbed:
+    async def test_returns_empty_for_empty_input(self) -> None:
+        client = EmbeddingClient("http://localhost:8001")
+        result = await client.embed([])
+        assert result == []
+
+    async def test_calls_service_and_returns_embeddings(self) -> None:
+        client = EmbeddingClient("http://localhost:8001")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+            "model": "all-MiniLM-L6-v2",
+            "dimension": 2,
+        }
+
+        mock_http_client = AsyncMock()
+        mock_http_client.post.return_value = mock_response
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("infra.embedding_client.httpx.AsyncClient", return_value=mock_http_client):
+            result = await client.embed(["hello", "world"])
+
+        assert result == [[0.1, 0.2], [0.3, 0.4]]
+        mock_http_client.post.assert_awaited_once_with(
+            "http://localhost:8001/embed",
+            json={"texts": ["hello", "world"]},
+        )
+
+    async def test_strips_trailing_slash_from_base_url(self) -> None:
+        client = EmbeddingClient("http://localhost:8001/")
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"embeddings": [[0.1]], "model": "m", "dimension": 1}
+
+        mock_http_client = AsyncMock()
+        mock_http_client.post.return_value = mock_response
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("infra.embedding_client.httpx.AsyncClient", return_value=mock_http_client):
+            await client.embed(["test"])
+
+        mock_http_client.post.assert_awaited_once_with(
+            "http://localhost:8001/embed",
+            json={"texts": ["test"]},
+        )
+
+    async def test_splits_large_batches(self) -> None:
+        client = EmbeddingClient("http://localhost:8001")
+        texts = [f"text_{i}" for i in range(_MAX_BATCH + 10)]
+
+        call_count = 0
+
+        def make_response(batch_size: int) -> MagicMock:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "embeddings": [[0.1]] * batch_size,
+                "model": "m",
+                "dimension": 1,
+            }
+            return resp
+
+        async def mock_post(url: str, json: dict) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            return make_response(len(json["texts"]))
+
+        mock_http_client = AsyncMock()
+        mock_http_client.post = mock_post
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("infra.embedding_client.httpx.AsyncClient", return_value=mock_http_client):
+            result = await client.embed(texts)
+
+        assert len(result) == _MAX_BATCH + 10
+        assert call_count == 2  # _MAX_BATCH + 10 remaining
+
+
+# -- max batch constant --------------------------------------------------------
+
+
+class TestMaxBatch:
+    def test_max_batch_is_256(self) -> None:
+        assert _MAX_BATCH == 256

--- a/document-parser/tests/test_opensearch_store.py
+++ b/document-parser/tests/test_opensearch_store.py
@@ -1,0 +1,320 @@
+"""Tests for the OpenSearch adapter (infra.opensearch_store).
+
+These tests mock the AsyncOpenSearch client to validate adapter logic
+without requiring a running OpenSearch instance.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from domain.ports import VectorStore
+from domain.vector_schema import (
+    ChunkBboxEntry,
+    ChunkOrigin,
+    DocItemRef,
+    IndexedChunk,
+    SearchResult,
+    build_index_mapping,
+)
+from infra.opensearch_store import OpenSearchStore, _hit_to_indexed_chunk, _hit_to_result
+
+# -- Fixtures -----------------------------------------------------------------
+
+
+def _make_chunk(
+    doc_id: str = "doc-1",
+    chunk_index: int = 0,
+    content: str = "hello world",
+    embedding: list[float] | None = None,
+) -> IndexedChunk:
+    return IndexedChunk(
+        doc_id=doc_id,
+        filename="test.pdf",
+        content=content,
+        embedding=embedding or [0.1, 0.2, 0.3],
+        chunk_index=chunk_index,
+        chunk_type="text",
+        page_number=1,
+        bboxes=[ChunkBboxEntry(page=1, x=0.0, y=0.0, w=100.0, h=50.0)],
+        headings=["Chapter 1"],
+        doc_items=[DocItemRef(self_ref="#/texts/0", label="text")],
+        origin=ChunkOrigin(binary_hash="abc123", filename="test.pdf"),
+    )
+
+
+def _make_hit(
+    doc_id: str = "doc-1",
+    chunk_index: int = 0,
+    score: float = 0.95,
+    content: str = "hello world",
+) -> dict:
+    return {
+        "_id": f"{doc_id}_{chunk_index}",
+        "_score": score,
+        "_source": {
+            "doc_id": doc_id,
+            "filename": "test.pdf",
+            "content": content,
+            "chunk_index": chunk_index,
+            "chunk_type": "text",
+            "page_number": 1,
+            "bboxes": [{"page": 1, "x": 0.0, "y": 0.0, "w": 100.0, "h": 50.0}],
+            "headings": ["Chapter 1"],
+            "doc_items": [{"self_ref": "#/texts/0", "label": "text"}],
+            "origin": {"binary_hash": "abc123", "filename": "test.pdf"},
+        },
+    }
+
+
+@pytest.fixture
+def store() -> OpenSearchStore:
+    return OpenSearchStore("http://localhost:9200")
+
+
+@pytest.fixture
+def mock_client(store: OpenSearchStore) -> AsyncMock:
+    client = AsyncMock()
+    store._client = client
+    return client
+
+
+# -- Protocol satisfaction -----------------------------------------------------
+
+
+class TestProtocolSatisfaction:
+    def test_satisfies_vector_store_protocol(self) -> None:
+        """OpenSearchStore structurally satisfies VectorStore Protocol."""
+        store = OpenSearchStore("http://localhost:9200")
+        assert isinstance(store, VectorStore)
+
+
+# -- Hit deserialization -------------------------------------------------------
+
+
+class TestHitDeserialization:
+    def test_hit_to_indexed_chunk(self) -> None:
+        hit = _make_hit()
+        chunk = _hit_to_indexed_chunk(hit)
+        assert isinstance(chunk, IndexedChunk)
+        assert chunk.doc_id == "doc-1"
+        assert chunk.content == "hello world"
+        assert chunk.chunk_index == 0
+        assert chunk.page_number == 1
+        assert len(chunk.bboxes) == 1
+        assert chunk.bboxes[0].w == 100.0
+        assert len(chunk.doc_items) == 1
+        assert chunk.doc_items[0].label == "text"
+        assert chunk.origin is not None
+        assert chunk.origin.binary_hash == "abc123"
+
+    def test_hit_to_indexed_chunk_no_origin(self) -> None:
+        hit = _make_hit()
+        hit["_source"]["origin"] = None
+        chunk = _hit_to_indexed_chunk(hit)
+        assert chunk.origin is None
+
+    def test_hit_to_indexed_chunk_missing_optional_fields(self) -> None:
+        hit = _make_hit()
+        del hit["_source"]["bboxes"]
+        del hit["_source"]["headings"]
+        del hit["_source"]["doc_items"]
+        del hit["_source"]["origin"]
+        chunk = _hit_to_indexed_chunk(hit)
+        assert chunk.bboxes == []
+        assert chunk.headings == []
+        assert chunk.doc_items == []
+        assert chunk.origin is None
+
+    def test_hit_to_result(self) -> None:
+        hit = _make_hit(score=0.87)
+        result = _hit_to_result(hit)
+        assert isinstance(result, SearchResult)
+        assert result.score == 0.87
+        assert result.chunk.doc_id == "doc-1"
+
+
+# -- ensure_index --------------------------------------------------------------
+
+
+class TestEnsureIndex:
+    async def test_creates_index_when_not_exists(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.indices.exists.return_value = False
+        mapping = build_index_mapping()
+        await store.ensure_index("test-index", mapping)
+        mock_client.indices.create.assert_awaited_once_with(index="test-index", body=mapping)
+
+    async def test_noop_when_index_exists(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.indices.exists.return_value = True
+        await store.ensure_index("test-index", {})
+        mock_client.indices.create.assert_not_awaited()
+
+
+# -- index_chunks --------------------------------------------------------------
+
+
+class TestIndexChunks:
+    async def test_bulk_indexes_chunks(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        chunks = [_make_chunk(chunk_index=0), _make_chunk(chunk_index=1)]
+        mock_client.bulk.return_value = {
+            "errors": False,
+            "items": [
+                {"index": {"_id": "doc-1_0", "status": 201}},
+                {"index": {"_id": "doc-1_1", "status": 201}},
+            ],
+        }
+        count = await store.index_chunks("test-index", chunks)
+        assert count == 2
+        mock_client.bulk.assert_awaited_once()
+
+    async def test_returns_zero_for_empty_list(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        count = await store.index_chunks("test-index", [])
+        assert count == 0
+        mock_client.bulk.assert_not_awaited()
+
+    async def test_counts_partial_failures(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        chunks = [_make_chunk(chunk_index=0), _make_chunk(chunk_index=1)]
+        mock_client.bulk.return_value = {
+            "errors": True,
+            "items": [
+                {"index": {"_id": "doc-1_0", "status": 201}},
+                {"index": {"_id": "doc-1_1", "error": {"reason": "mapping"}}},
+            ],
+        }
+        count = await store.index_chunks("test-index", chunks)
+        assert count == 1
+
+    async def test_bulk_body_structure(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        chunk = _make_chunk(doc_id="d1", chunk_index=3)
+        mock_client.bulk.return_value = {
+            "errors": False,
+            "items": [{"index": {"_id": "d1_3", "status": 201}}],
+        }
+        await store.index_chunks("idx", [chunk])
+        call_body = mock_client.bulk.call_args[1]["body"]
+        assert call_body[0] == {"index": {"_index": "idx", "_id": "d1_3"}}
+        assert call_body[1]["doc_id"] == "d1"
+        assert call_body[1]["chunk_index"] == 3
+
+
+# -- search_similar ------------------------------------------------------------
+
+
+class TestSearchSimilar:
+    async def test_knn_search(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.search.return_value = {"hits": {"hits": [_make_hit(score=0.99)]}}
+        results = await store.search_similar("idx", [0.1, 0.2, 0.3], k=5)
+        assert len(results) == 1
+        assert results[0].score == 0.99
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["query"]["knn"]["embedding"]["vector"] == [0.1, 0.2, 0.3]
+        assert call_body["query"]["knn"]["embedding"]["k"] == 5
+
+    async def test_knn_search_with_doc_filter(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.search_similar("idx", [0.1], doc_id="doc-42")
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["query"]["knn"]["embedding"]["filter"] == {"term": {"doc_id": "doc-42"}}
+
+    async def test_knn_search_no_filter_by_default(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.search_similar("idx", [0.1])
+        call_body = mock_client.search.call_args[1]["body"]
+        assert "filter" not in call_body["query"]["knn"]["embedding"]
+
+
+# -- get_chunks ----------------------------------------------------------------
+
+
+class TestGetChunks:
+    async def test_retrieves_by_doc_id(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {
+            "hits": {"hits": [_make_hit(chunk_index=0), _make_hit(chunk_index=1)]}
+        }
+        results = await store.get_chunks("idx", "doc-1")
+        assert len(results) == 2
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["query"] == {"term": {"doc_id": "doc-1"}}
+        assert call_body["sort"] == [{"chunk_index": {"order": "asc"}}]
+
+    async def test_respects_limit(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.get_chunks("idx", "doc-1", limit=50)
+        call_body = mock_client.search.call_args[1]["body"]
+        assert call_body["size"] == 50
+
+
+# -- delete_document -----------------------------------------------------------
+
+
+class TestDeleteDocument:
+    async def test_deletes_by_doc_id(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.delete_by_query.return_value = {"deleted": 5}
+        count = await store.delete_document("idx", "doc-1")
+        assert count == 5
+        call_body = mock_client.delete_by_query.call_args[1]["body"]
+        assert call_body["query"] == {"term": {"doc_id": "doc-1"}}
+
+    async def test_returns_zero_on_not_found(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        from opensearchpy import NotFoundError
+
+        mock_client.delete_by_query.side_effect = NotFoundError(404, "index_not_found")
+        count = await store.delete_document("idx", "doc-1")
+        assert count == 0
+
+
+# -- search_fulltext -----------------------------------------------------------
+
+
+class TestSearchFulltext:
+    async def test_fulltext_search(self, store: OpenSearchStore, mock_client: AsyncMock) -> None:
+        mock_client.search.return_value = {
+            "hits": {"hits": [_make_hit(content="matching text", score=1.5)]}
+        }
+        results = await store.search_fulltext("idx", "matching")
+        assert len(results) == 1
+        assert results[0].chunk.content == "matching text"
+        call_body = mock_client.search.call_args[1]["body"]
+        assert {"match": {"content": "matching"}} in call_body["query"]["bool"]["must"]
+
+    async def test_fulltext_search_with_doc_filter(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        mock_client.search.return_value = {"hits": {"hits": []}}
+        await store.search_fulltext("idx", "query", doc_id="doc-5")
+        call_body = mock_client.search.call_args[1]["body"]
+        must_clauses = call_body["query"]["bool"]["must"]
+        assert {"term": {"doc_id": "doc-5"}} in must_clauses
+
+
+# -- close ---------------------------------------------------------------------
+
+
+class TestClose:
+    async def test_close_delegates_to_client(
+        self, store: OpenSearchStore, mock_client: AsyncMock
+    ) -> None:
+        await store.close()
+        mock_client.close.assert_awaited_once()

--- a/document-parser/tests/test_vector_schema.py
+++ b/document-parser/tests/test_vector_schema.py
@@ -11,6 +11,7 @@ from domain.vector_schema import (
     ChunkOrigin,
     DocItemRef,
     IndexedChunk,
+    SearchResult,
     build_index_mapping,
 )
 
@@ -187,6 +188,36 @@ class TestBuildIndexMapping:
         props = mapping["mappings"]["properties"]
         for field_name in ("chunk_index", "page_number"):
             assert props[field_name]["type"] == "integer", f"{field_name} should be integer"
+
+
+class TestSearchResult:
+    def test_construction(self):
+        chunk = IndexedChunk(
+            doc_id="doc-1",
+            filename="test.pdf",
+            content="Hello",
+            embedding=[0.1] * 384,
+            chunk_index=0,
+            chunk_type="text",
+            page_number=1,
+        )
+        result = SearchResult(chunk=chunk, score=0.95)
+        assert result.chunk.content == "Hello"
+        assert result.score == 0.95
+
+    def test_frozen(self):
+        chunk = IndexedChunk(
+            doc_id="d",
+            filename="f",
+            content="c",
+            embedding=[],
+            chunk_index=0,
+            chunk_type="text",
+            page_number=1,
+        )
+        result = SearchResult(chunk=chunk, score=0.5)
+        with pytest.raises(AttributeError):
+            result.score = 0.9  # type: ignore[misc]
 
 
 class TestConstants:

--- a/document-parser/tests/test_vector_schema.py
+++ b/document-parser/tests/test_vector_schema.py
@@ -1,0 +1,197 @@
+"""Tests for vector index schema — value objects and OpenSearch mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.vector_schema import (
+    DEFAULT_EMBEDDING_DIMENSION,
+    DEFAULT_INDEX_NAME,
+    ChunkBboxEntry,
+    ChunkOrigin,
+    DocItemRef,
+    IndexedChunk,
+    build_index_mapping,
+)
+
+
+class TestChunkBboxEntry:
+    def test_construction(self):
+        bbox = ChunkBboxEntry(page=1, x=10.0, y=20.0, w=100.0, h=50.0)
+        assert bbox.page == 1
+        assert bbox.x == 10.0
+        assert bbox.w == 100.0
+
+    def test_frozen(self):
+        bbox = ChunkBboxEntry(page=1, x=0, y=0, w=10, h=10)
+        with pytest.raises(AttributeError):
+            bbox.page = 2  # type: ignore[misc]
+
+
+class TestDocItemRef:
+    def test_construction(self):
+        ref = DocItemRef(self_ref="#/texts/0", label="text")
+        assert ref.self_ref == "#/texts/0"
+        assert ref.label == "text"
+
+
+class TestChunkOrigin:
+    def test_construction(self):
+        origin = ChunkOrigin(binary_hash="abc123", filename="doc.pdf")
+        assert origin.binary_hash == "abc123"
+        assert origin.filename == "doc.pdf"
+
+
+class TestIndexedChunk:
+    def _make_chunk(self, **overrides) -> IndexedChunk:
+        defaults = {
+            "doc_id": "doc-1",
+            "filename": "test.pdf",
+            "content": "Hello world",
+            "embedding": [0.1] * 384,
+            "chunk_index": 0,
+            "chunk_type": "text",
+            "page_number": 1,
+        }
+        defaults.update(overrides)
+        return IndexedChunk(**defaults)
+
+    def test_minimal_chunk(self):
+        chunk = self._make_chunk()
+        assert chunk.doc_id == "doc-1"
+        assert chunk.content == "Hello world"
+        assert chunk.bboxes == []
+        assert chunk.headings == []
+        assert chunk.doc_items == []
+        assert chunk.origin is None
+
+    def test_full_chunk(self):
+        chunk = self._make_chunk(
+            bboxes=[ChunkBboxEntry(page=1, x=10, y=20, w=100, h=50)],
+            headings=["Chapter 1", "Section A"],
+            doc_items=[DocItemRef(self_ref="#/texts/0", label="text")],
+            origin=ChunkOrigin(binary_hash="abc", filename="test.pdf"),
+        )
+        assert len(chunk.bboxes) == 1
+        assert chunk.headings == ["Chapter 1", "Section A"]
+        assert chunk.doc_items[0].label == "text"
+        assert chunk.origin.binary_hash == "abc"
+
+    def test_to_dict_minimal(self):
+        chunk = self._make_chunk()
+        d = chunk.to_dict()
+        assert d["doc_id"] == "doc-1"
+        assert d["filename"] == "test.pdf"
+        assert d["content"] == "Hello world"
+        assert d["embedding"] == [0.1] * 384
+        assert d["chunk_index"] == 0
+        assert d["chunk_type"] == "text"
+        assert d["page_number"] == 1
+        assert d["bboxes"] == []
+        assert d["headings"] == []
+        assert d["doc_items"] == []
+        assert "origin" not in d
+
+    def test_to_dict_full(self):
+        chunk = self._make_chunk(
+            bboxes=[ChunkBboxEntry(page=1, x=10.5, y=20.0, w=100.0, h=50.0)],
+            headings=["H1"],
+            doc_items=[DocItemRef(self_ref="#/texts/0", label="text")],
+            origin=ChunkOrigin(binary_hash="abc", filename="test.pdf"),
+        )
+        d = chunk.to_dict()
+        assert d["bboxes"] == [{"page": 1, "x": 10.5, "y": 20.0, "w": 100.0, "h": 50.0}]
+        assert d["headings"] == ["H1"]
+        assert d["doc_items"] == [{"self_ref": "#/texts/0", "label": "text"}]
+        assert d["origin"] == {"binary_hash": "abc", "filename": "test.pdf"}
+
+    def test_frozen(self):
+        chunk = self._make_chunk()
+        with pytest.raises(AttributeError):
+            chunk.content = "modified"  # type: ignore[misc]
+
+
+class TestBuildIndexMapping:
+    def test_default_dimension(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        assert props["embedding"]["dimension"] == 384
+        assert props["embedding"]["type"] == "knn_vector"
+        assert props["embedding"]["method"]["engine"] == "faiss"
+        assert props["embedding"]["method"]["name"] == "hnsw"
+
+    def test_custom_dimension(self):
+        mapping = build_index_mapping(embedding_dimension=768)
+        assert mapping["mappings"]["properties"]["embedding"]["dimension"] == 768
+
+    def test_knn_enabled(self):
+        mapping = build_index_mapping()
+        assert mapping["settings"]["index"]["knn"] is True
+
+    def test_all_fields_present(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        expected_fields = {
+            "doc_id",
+            "filename",
+            "content",
+            "embedding",
+            "chunk_index",
+            "chunk_type",
+            "page_number",
+            "bboxes",
+            "headings",
+            "doc_items",
+            "origin",
+        }
+        assert set(props.keys()) == expected_fields
+
+    def test_bboxes_nested_type(self):
+        mapping = build_index_mapping()
+        bboxes = mapping["mappings"]["properties"]["bboxes"]
+        assert bboxes["type"] == "nested"
+        assert "page" in bboxes["properties"]
+        assert "x" in bboxes["properties"]
+        assert "y" in bboxes["properties"]
+        assert "w" in bboxes["properties"]
+        assert "h" in bboxes["properties"]
+
+    def test_doc_items_nested_type(self):
+        mapping = build_index_mapping()
+        doc_items = mapping["mappings"]["properties"]["doc_items"]
+        assert doc_items["type"] == "nested"
+        assert "self_ref" in doc_items["properties"]
+        assert "label" in doc_items["properties"]
+
+    def test_origin_object_type(self):
+        mapping = build_index_mapping()
+        origin = mapping["mappings"]["properties"]["origin"]
+        assert origin["type"] == "object"
+        assert "binary_hash" in origin["properties"]
+        assert "filename" in origin["properties"]
+
+    def test_content_uses_standard_analyzer(self):
+        mapping = build_index_mapping()
+        content = mapping["mappings"]["properties"]["content"]
+        assert content["type"] == "text"
+        assert content["analyzer"] == "standard"
+
+    def test_keyword_fields(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        for field_name in ("doc_id", "filename", "chunk_type"):
+            assert props[field_name]["type"] == "keyword", f"{field_name} should be keyword"
+
+    def test_integer_fields(self):
+        mapping = build_index_mapping()
+        props = mapping["mappings"]["properties"]
+        for field_name in ("chunk_index", "page_number"):
+            assert props[field_name]["type"] == "integer", f"{field_name} should be integer"
+
+
+class TestConstants:
+    def test_default_embedding_dimension(self):
+        assert DEFAULT_EMBEDDING_DIMENSION == 384
+
+    def test_default_index_name(self):
+        assert DEFAULT_INDEX_NAME == "docling-studio-chunks"

--- a/document-parser/tests/test_vector_store_port.py
+++ b/document-parser/tests/test_vector_store_port.py
@@ -1,0 +1,113 @@
+"""Tests for VectorStore port — verify the protocol contract is implementable."""
+
+from __future__ import annotations
+
+import pytest
+
+from domain.ports import VectorStore
+from domain.vector_schema import IndexedChunk, SearchResult
+
+
+class FakeVectorStore:
+    """Minimal concrete implementation to verify the protocol is implementable."""
+
+    async def ensure_index(self, index_name: str, mapping: dict) -> None:
+        pass
+
+    async def index_chunks(self, index_name: str, chunks: list[IndexedChunk]) -> int:
+        return len(chunks)
+
+    async def search_similar(
+        self,
+        index_name: str,
+        embedding: list[float],
+        *,
+        k: int = 10,
+        doc_id: str | None = None,
+    ) -> list[SearchResult]:
+        return []
+
+    async def get_chunks(
+        self,
+        index_name: str,
+        doc_id: str,
+        *,
+        limit: int = 1000,
+    ) -> list[SearchResult]:
+        return []
+
+    async def delete_document(self, index_name: str, doc_id: str) -> int:
+        return 0
+
+
+class TestVectorStorePort:
+    def test_fake_satisfies_protocol(self):
+        """A class implementing all methods is accepted as a VectorStore."""
+        store: VectorStore = FakeVectorStore()
+        assert store is not None
+
+    @pytest.mark.asyncio
+    async def test_ensure_index(self):
+        store = FakeVectorStore()
+        await store.ensure_index("test-index", {"mappings": {}})
+
+    @pytest.mark.asyncio
+    async def test_index_chunks(self):
+        store = FakeVectorStore()
+        chunk = IndexedChunk(
+            doc_id="d1",
+            filename="test.pdf",
+            content="Hello",
+            embedding=[0.1] * 384,
+            chunk_index=0,
+            chunk_type="text",
+            page_number=1,
+        )
+        count = await store.index_chunks("test-index", [chunk])
+        assert count == 1
+
+    @pytest.mark.asyncio
+    async def test_search_similar(self):
+        store = FakeVectorStore()
+        results = await store.search_similar("test-index", [0.1] * 384, k=5)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_similar_with_doc_filter(self):
+        store = FakeVectorStore()
+        results = await store.search_similar("test-index", [0.1] * 384, k=5, doc_id="d1")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_chunks(self):
+        store = FakeVectorStore()
+        results = await store.get_chunks("test-index", "d1")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_get_chunks_with_limit(self):
+        store = FakeVectorStore()
+        results = await store.get_chunks("test-index", "d1", limit=50)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_delete_document(self):
+        store = FakeVectorStore()
+        count = await store.delete_document("test-index", "d1")
+        assert count == 0
+
+    def test_protocol_methods_list(self):
+        """Verify the protocol exposes the expected methods."""
+        expected = {
+            "ensure_index",
+            "index_chunks",
+            "search_similar",
+            "get_chunks",
+            "delete_document",
+        }
+        protocol_methods = {
+            name
+            for name in dir(VectorStore)
+            if not name.startswith("_") and callable(getattr(VectorStore, name, None))
+        }
+        assert expected.issubset(protocol_methods)

--- a/embedding-service/Dockerfile
+++ b/embedding-service/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies first (cache layer)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Pre-download default model into the image
+ARG EMBEDDING_MODEL=all-MiniLM-L6-v2
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('${EMBEDDING_MODEL}')"
+
+COPY main.py .
+
+EXPOSE 8001
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/embedding-service/main.py
+++ b/embedding-service/main.py
@@ -1,0 +1,89 @@
+"""Embedding microservice — exposes sentence-transformers models via REST API.
+
+POST /embed  {"texts": ["...", "..."]}  →  {"embeddings": [[...], [...]], "model": "...", "dimension": N}
+GET  /health                            →  {"status": "ok", "model": "...", "dimension": N}
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from sentence_transformers import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = os.environ.get("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+BATCH_SIZE = int(os.environ.get("EMBEDDING_BATCH_SIZE", "64"))
+
+app = FastAPI(title="Docling Studio — Embedding Service", version="0.4.0")
+
+# Load model at startup (downloaded / cached in HF cache dir)
+model: SentenceTransformer | None = None
+
+
+@app.on_event("startup")
+async def _load_model() -> None:
+    global model  # noqa: PLW0603
+    logger.info("Loading sentence-transformers model '%s' …", MODEL_NAME)
+    t0 = time.monotonic()
+    model = SentenceTransformer(MODEL_NAME)
+    elapsed = time.monotonic() - t0
+    dim = model.get_sentence_embedding_dimension()
+    logger.info("Model loaded in %.1fs — dimension=%d", elapsed, dim)
+
+
+# -- Schemas -------------------------------------------------------------------
+
+
+class EmbedRequest(BaseModel):
+    texts: list[str] = Field(..., min_length=1, description="Texts to embed")
+
+
+class EmbedResponse(BaseModel):
+    embeddings: list[list[float]]
+    model: str
+    dimension: int
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model: str
+    dimension: int
+
+
+# -- Endpoints -----------------------------------------------------------------
+
+
+@app.post("/embed", response_model=EmbedResponse)
+async def embed(request: EmbedRequest) -> EmbedResponse:
+    """Generate embeddings for a batch of texts."""
+    if model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+
+    vectors = model.encode(
+        request.texts,
+        batch_size=BATCH_SIZE,
+        show_progress_bar=False,
+        normalize_embeddings=True,
+    )
+    return EmbedResponse(
+        embeddings=vectors.tolist(),
+        model=MODEL_NAME,
+        dimension=model.get_sentence_embedding_dimension(),
+    )
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Health check — verifies the model is loaded."""
+    if model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+    return HealthResponse(
+        status="ok",
+        model=MODEL_NAME,
+        dimension=model.get_sentence_embedding_dimension(),
+    )

--- a/embedding-service/requirements.txt
+++ b/embedding-service/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.115.0,<1.0.0
+uvicorn[standard]>=0.32.0,<1.0.0
+sentence-transformers>=3.0.0,<4.0.0

--- a/embedding-service/test_main.py
+++ b/embedding-service/test_main.py
@@ -1,0 +1,64 @@
+"""Tests for the embedding microservice API."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+import main
+
+
+@pytest.fixture(autouse=True)
+def _mock_model() -> None:
+    """Inject a mock SentenceTransformer model for all tests."""
+    mock = MagicMock()
+    mock.get_sentence_embedding_dimension.return_value = 3
+    mock.encode.return_value = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+    main.model = mock
+    yield
+    main.model = None
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(main.app)
+
+
+class TestEmbed:
+    def test_embed_returns_vectors(self, client: TestClient) -> None:
+        resp = client.post("/embed", json={"texts": ["hello", "world"]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["embeddings"]) == 2
+        assert data["dimension"] == 3
+        assert data["model"] == main.MODEL_NAME
+
+    def test_embed_empty_texts_rejected(self, client: TestClient) -> None:
+        resp = client.post("/embed", json={"texts": []})
+        assert resp.status_code == 422
+
+    def test_embed_missing_texts(self, client: TestClient) -> None:
+        resp = client.post("/embed", json={})
+        assert resp.status_code == 422
+
+    def test_embed_model_not_loaded(self, client: TestClient) -> None:
+        main.model = None
+        resp = client.post("/embed", json={"texts": ["test"]})
+        assert resp.status_code == 503
+
+
+class TestHealth:
+    def test_health_ok(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["dimension"] == 3
+
+    def test_health_model_not_loaded(self, client: TestClient) -> None:
+        main.model = None
+        resp = client.get("/health")
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary

- Add standalone embedding microservice (`embedding-service/`) with FastAPI + sentence-transformers
  - `POST /embed` — batch text-to-vector, default model `all-MiniLM-L6-v2`
  - `GET /health` — readiness check with model/dimension info
  - Dockerfile with pre-downloaded model for fast cold starts
- Add `EmbeddingService` Protocol port in `domain/ports.py`
- Add `EmbeddingClient` HTTP adapter in `infra/embedding_client.py` (auto-splits large batches)
- Add `EMBEDDING_URL` setting and env var
- Wire embedding service into `docker-compose.dev.yml` with health check

Closes #71

## Test plan

- [x] `EmbeddingClient` satisfies `EmbeddingService` Protocol
- [x] 6 unit tests for client adapter (empty input, batch splitting, URL normalization)
- [x] 6 unit tests for microservice API (embed, health, error cases)
- [x] 351 document-parser tests pass, zero lint violations