### PR TITLE
fix(e2e): replace fragile index-based toggle selection with dedicated selectors

### DIFF
--- a/e2e/ui/src/test/resources/analyses/pipeline-options.feature
+++ b/e2e/ui/src/test/resources/analyses/pipeline-options.feature
@@ -51,10 +51,9 @@ Feature: UI — Pipeline configuration options
     * select('[data-e2e=config-select]', 'fast')
 
     # Switch to Verify mode and back
-    * def toggleBtns = locateAll('[data-e2e=toggle-btn]')
-    * toggleBtns[1].click()
-    * waitFor('[data-e2e=toggle-btn].active')
-    * toggleBtns[0].click()
+    * click('[data-e2e~=verify-btn]')
+    * waitFor('[data-e2e~=verify-btn].active')
+    * click('[data-e2e~=configure-btn]')
     * waitFor('[data-e2e=config-select]')
 
     # Verify table mode is still fast

--- a/e2e/ui/src/test/resources/analyses/rechunk.feature
+++ b/e2e/ui/src/test/resources/analyses/rechunk.feature
@@ -25,9 +25,9 @@ Feature: UI — Rechunk an analysis with different parameters
     * call read('classpath:common/helpers/ui-wait-analysis.feature')
     * waitFor('[data-e2e=result-tabs]')
 
-    # Now Préparer toggle should be enabled — click the last one
-    * def toggleBtns = locateAll('[data-e2e=toggle-btn]')
-    * toggleBtns[karate.sizeOf(toggleBtns) - 1].click()
+    # Switch to Prepare tab — use dedicated selector (avoids race with feature flag load)
+    * waitFor('[data-e2e~=prepare-btn]')
+    * click('[data-e2e~=prepare-btn]')
 
     # Wait for chunk panel to load
     * waitFor('[data-e2e=chunk-panel]')

--- a/e2e/ui/src/test/resources/workflows/full-ui-path.feature
+++ b/e2e/ui/src/test/resources/workflows/full-ui-path.feature
@@ -46,8 +46,8 @@ Feature: UI — Full happy path via browser
     * match text('[data-e2e=raw-content]') != ''
 
     # Step 9: Switch to Préparer mode and rechunk
-    * def toggleBtns = locateAll('[data-e2e=toggle-btn]')
-    * toggleBtns[karate.sizeOf(toggleBtns) - 1].click()
+    * waitFor('[data-e2e~=prepare-btn]')
+    * click('[data-e2e~=prepare-btn]')
     * waitFor('[data-e2e=chunk-panel]')
 
     # Expand config if needed
@@ -66,8 +66,7 @@ Feature: UI — Full happy path via browser
     * assert karate.sizeOf(locateAll('[data-e2e=chunk-card]')) > 0
 
     # Step 10: Delete the document via UI
-    * def toggleBtns2 = locateAll('[data-e2e=toggle-btn]')
-    * toggleBtns2[0].click()
+    * click('[data-e2e~=configure-btn]')
     * waitFor('[data-e2e=doc-item]')
 
     # Hover and delete

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -22,7 +22,7 @@
         <div class="mode-toggle">
           <button
             class="toggle-btn"
-            data-e2e="toggle-btn"
+            data-e2e="toggle-btn configure-btn"
             :class="{ active: mode === 'configure' }"
             @click="mode = 'configure'"
           >
@@ -37,7 +37,7 @@
           </button>
           <button
             class="toggle-btn"
-            data-e2e="toggle-btn"
+            data-e2e="toggle-btn verify-btn"
             :class="{ active: mode === 'verify' }"
             @click="mode = 'verify'"
             :disabled="!analysisStore.currentAnalysis"
@@ -54,7 +54,7 @@
           <button
             v-if="chunkingEnabled"
             class="toggle-btn"
-            data-e2e="toggle-btn"
+            data-e2e="toggle-btn prepare-btn"
             :class="{ active: mode === 'prepare' }"
             @click="mode = 'prepare'"
             :disabled="!analysisStore.currentAnalysis"


### PR DESCRIPTION
## Summary

- Add dedicated `data-e2e` selectors (`configure-btn`, `verify-btn`, `prepare-btn`) to StudioPage toggle buttons
- Update 3 E2E tests (`rechunk.feature`, `full-ui-path.feature`, `pipeline-options.feature`) to use `waitFor` + `click` on dedicated selectors instead of `locateAll` index tricks
- Fixes timeout caused by race condition with async feature flag loading — `locateAll` could run before the chunking flag loaded, returning only 2 buttons instead of 3

## Test plan

- [ ] Vérifier que le Release Gate passe (E2E UI @critical)
- [ ] Vérifier manuellement que les 3 boutons toggle fonctionnent sur `/studio`

Closes #176