### PR TITLE
fix(e2e): use word-match selector for remaining toggle-btn references

### DIFF
--- a/e2e/ui/src/test/resources/analyses/analysis.feature
+++ b/e2e/ui/src/test/resources/analyses/analysis.feature
@@ -18,7 +18,7 @@ Feature: UI — Launch an analysis and verify results
     * waitFor('[data-e2e=doc-item].selected')
 
     # Verify we are in Configure mode (first toggle button is active)
-    * waitFor('[data-e2e=toggle-btn].active')
+    * waitFor('[data-e2e~=configure-btn].active')
 
     # Click Run / Exécuter
     * waitFor('[data-e2e=run-btn]')

--- a/e2e/ui/src/test/resources/workflows/full-ui-path.feature
+++ b/e2e/ui/src/test/resources/workflows/full-ui-path.feature
@@ -22,7 +22,7 @@ Feature: UI — Full happy path via browser
     * waitFor('[data-e2e=doc-item].selected')
 
     # Step 5: Verify Configure mode is active
-    * waitFor('[data-e2e=toggle-btn].active')
+    * waitFor('[data-e2e~=configure-btn].active')
 
     # Step 6: Run the analysis
     * click('[data-e2e=run-btn]')


### PR DESCRIPTION
## Summary

- Fix 2 remaining E2E tests (`analysis.feature:21`, `full-ui-path.feature:25`) that still used exact-match `[data-e2e=toggle-btn]`
- After #178, toggle buttons have compound `data-e2e` values (e.g. `"toggle-btn configure-btn"`), so exact match `=` no longer works → switch to word-match `~=`

## Root cause

PR #178 was merged with only the first commit. The second commit fixing these 2 remaining files was pushed after merge and never reached `release/0.4.0`.

## Test plan

- [ ] Release Gate E2E UI tests pass

Closes #176