### PR TITLE
fix(ci): ignore CVE-2026-40393 (Mesa) to unblock release gate

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,12 @@
+vulnerabilities:
+  - id: CVE-2026-40393
+    paths:
+      - "usr/lib/x86_64-linux-gnu/libgbm.so.*"
+      - "usr/lib/x86_64-linux-gnu/dri/*"
+      - "usr/lib/x86_64-linux-gnu/libGLX_mesa.so.*"
+      - "usr/lib/x86_64-linux-gnu/libgallium-*.so"
+    statement: >-
+      Mesa OOB read (fix: Mesa 25.3.6 / 26.0.1). No Debian 13 backport available.
+      Pulled transitively by libgl1 (required by OpenCV/RapidOCR). Tracked in #189
+      with follow-up to drop libgl1 via opencv-python-headless.
+    expired_at: 2026-06-30


### PR DESCRIPTION
## Summary
- Ajoute `.trivyignore.yaml` avec **CVE-2026-40393** uniquement, `expired_at: 2026-06-30` et justification.
- Mesa OOB read (fix upstream 25.3.6 / 26.0.1) sans backport Debian 13 → impossible à corriger par `apt-get upgrade` aujourd'hui.
- Tiré transitivement par `libgl1` (OpenCV / RapidOCR) dans le stage `local` du Dockerfile.
- Follow-up pour supprimer `libgl1` (via `opencv-python-headless`) tracké dans #189.

## Test plan
- [ ] Release Gate vert sur cette PR (Trivy CRITICAL passe, HIGH reste informational)
- [ ] Annotation Trivy HIGH toujours visible
- [ ] Artefact `trivy-local` téléchargeable, summary = 0 CRITICAL

Closes #189