### PR TITLE
feat(#210): feature-flag mode gating + deep-link redirect

### DIFF
--- a/document-parser/api/schemas.py
+++ b/document-parser/api/schemas.py
@@ -46,6 +46,12 @@ class HealthResponse(_CamelModel):
     # available: REASONING_ENABLED=true AND deps importable. Doesn't imply
     # Ollama itself is reachable — that's checked per-call.
     reasoning_available: bool = False
+    # 0.6.0 — Doc workspace mode flags (#210). Default true so existing
+    # frontends without the new keys (legacy backend image rolling forward)
+    # see the same behaviour they had.
+    inspect_mode_enabled: bool = True
+    chunks_mode_enabled: bool = True
+    ask_mode_enabled: bool = True
 
 
 class DocumentResponse(_CamelModel):

--- a/document-parser/infra/settings.py
+++ b/document-parser/infra/settings.py
@@ -55,6 +55,12 @@ class Settings:
     cors_origins: list[str] = field(
         default_factory=lambda: ["http://localhost:3000", "http://localhost:5173"]
     )
+    # 0.6.0 — Doc workspace mode flags (#210). All on by default to preserve
+    # existing behaviour; operators flip a flag off to hide a mode tab + redirect
+    # deep links. Per-tenant gating is out of scope for 0.6.0.
+    inspect_mode_enabled: bool = True
+    chunks_mode_enabled: bool = True
+    ask_mode_enabled: bool = True
 
     def __post_init__(self) -> None:
         errors: list[str] = []
@@ -153,6 +159,13 @@ class Settings:
             max_paste_image_size_mb=int(os.environ.get("MAX_PASTE_IMAGE_SIZE_MB", "10")),
             paste_allowed_image_types=[t.strip() for t in paste_types_raw.split(",") if t.strip()],
             cors_origins=[o.strip() for o in cors_raw.split(",")],
+            # 0.6.0 — Doc workspace mode flags (#210). Defaults: enabled.
+            inspect_mode_enabled=os.environ.get("INSPECT_MODE_ENABLED", "true").lower()
+            in ("1", "true", "yes", "on"),
+            chunks_mode_enabled=os.environ.get("CHUNKS_MODE_ENABLED", "true").lower()
+            in ("1", "true", "yes", "on"),
+            ask_mode_enabled=os.environ.get("ASK_MODE_ENABLED", "true").lower()
+            in ("1", "true", "yes", "on"),
         )
 
 

--- a/document-parser/main.py
+++ b/document-parser/main.py
@@ -304,4 +304,8 @@ async def health() -> HealthResponse:
         # actual Ollama reachability is checked lazily at call-time to avoid
         # blocking health checks on the LLM host.
         reasoning_available=runner is not None and runner.is_available,
+        # 0.6.0 — Doc workspace mode flags (#210).
+        inspect_mode_enabled=settings.inspect_mode_enabled,
+        chunks_mode_enabled=settings.chunks_mode_enabled,
+        ask_mode_enabled=settings.ask_mode_enabled,
     )

--- a/document-parser/tests/test_api_endpoints.py
+++ b/document-parser/tests/test_api_endpoints.py
@@ -68,6 +68,18 @@ class TestHealthEndpoint:
         data = resp.json()
         assert data["ingestionAvailable"] is True
 
+    def test_health_exposes_doc_mode_flags(self, client):
+        """0.6.0 (#210): /api/health surfaces inspect/chunks/ask mode flags."""
+        resp = client.get("/api/health")
+        data = resp.json()
+        assert "inspectModeEnabled" in data
+        assert "chunksModeEnabled" in data
+        assert "askModeEnabled" in data
+        # Defaults preserve current behaviour (all enabled).
+        assert data["inspectModeEnabled"] is True
+        assert data["chunksModeEnabled"] is True
+        assert data["askModeEnabled"] is True
+
 
 class TestDocumentEndpoints:
     def test_list_documents(self, client, mock_document_service):

--- a/frontend/src/app/router/index.ts
+++ b/frontend/src/app/router/index.ts
@@ -1,5 +1,9 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import { useFeatureFlagStore } from '../../features/feature-flags/store'
+import { isDocMode } from '../../shared/routing/modes'
+import { ROUTES } from '../../shared/routing/names'
+import { resolveMode } from '../../shared/routing/resolveMode'
 import { routes } from './routes'
 
 export { routes }
@@ -7,4 +11,38 @@ export { routes }
 export const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+/**
+ * Doc workspace mode guard (#210).
+ *
+ * - `/docs/:id?mode=<disabled>` → redirect with the same id but the
+ *   first enabled mode (ask > chunks > inspect priority).
+ * - All three modes off → redirect to `/docs?reason=no-mode-enabled`.
+ * - Any other route is left untouched.
+ *
+ * Pure resolution lives in `resolveMode`; the guard is just the
+ * router-level wiring.
+ */
+router.beforeEach((to) => {
+  if (to.name !== ROUTES.DOC_WORKSPACE) return true
+
+  const flags = useFeatureFlagStore().modeFlags()
+  const requestedRaw = Array.isArray(to.query.mode) ? to.query.mode[0] : to.query.mode
+  const requested = isDocMode(requestedRaw) ? requestedRaw : undefined
+  const resolved = resolveMode(requested, flags)
+
+  if (resolved === null) {
+    return {
+      name: ROUTES.DOCS_LIBRARY,
+      query: { reason: 'no-mode-enabled' },
+    }
+  }
+  if (resolved !== requested) {
+    return {
+      ...to,
+      query: { ...to.query, mode: resolved },
+    }
+  }
+  return true
 })

--- a/frontend/src/features/feature-flags/store.test.ts
+++ b/frontend/src/features/feature-flags/store.test.ts
@@ -155,4 +155,42 @@ describe('useFeatureFlagStore', () => {
     expect(store.isEnabled('chunking')).toBe(false)
     expect(store.isEnabled('disclaimer')).toBe(false)
   })
+
+  // 0.6.0 — Doc workspace mode flags (#210).
+  it('exposes inspectMode / chunksMode / askMode flags from /api/health', async () => {
+    mockApiFetch.mockResolvedValue({
+      status: 'ok',
+      engine: 'local',
+      inspectModeEnabled: false,
+      chunksModeEnabled: true,
+      askModeEnabled: true,
+    })
+    const store = useFeatureFlagStore()
+    await store.load()
+    expect(store.isEnabled('inspectMode')).toBe(false)
+    expect(store.isEnabled('chunksMode')).toBe(true)
+    expect(store.isEnabled('askMode')).toBe(true)
+  })
+
+  it('falls back to all-modes-enabled when /api/health omits the new fields', async () => {
+    mockApiFetch.mockResolvedValue({ status: 'ok', engine: 'local' })
+    const store = useFeatureFlagStore()
+    await store.load()
+    expect(store.isEnabled('inspectMode')).toBe(true)
+    expect(store.isEnabled('chunksMode')).toBe(true)
+    expect(store.isEnabled('askMode')).toBe(true)
+  })
+
+  it('modeFlags() returns the three flags in a Record<DocMode, boolean>', async () => {
+    mockApiFetch.mockResolvedValue({
+      status: 'ok',
+      engine: 'local',
+      inspectModeEnabled: true,
+      chunksModeEnabled: false,
+      askModeEnabled: true,
+    })
+    const store = useFeatureFlagStore()
+    await store.load()
+    expect(store.modeFlags()).toEqual({ ask: true, chunks: false, inspect: true })
+  })
 })

--- a/frontend/src/features/feature-flags/store.ts
+++ b/frontend/src/features/feature-flags/store.ts
@@ -15,9 +15,21 @@ interface HealthResponse {
   maxFileSizeMb?: number
   ingestionAvailable?: boolean
   reasoningAvailable?: boolean
+  // 0.6.0 — Doc workspace mode flags (#210). Optional so an older backend
+  // image without these fields keeps working: missing → fall back to true.
+  inspectModeEnabled?: boolean
+  chunksModeEnabled?: boolean
+  askModeEnabled?: boolean
 }
 
-export type FeatureFlag = 'chunking' | 'disclaimer' | 'ingestion' | 'reasoning'
+export type FeatureFlag =
+  | 'chunking'
+  | 'disclaimer'
+  | 'ingestion'
+  | 'reasoning'
+  | 'inspectMode'
+  | 'chunksMode'
+  | 'askMode'
 
 interface FeatureFlagDef {
   description: string
@@ -29,6 +41,9 @@ interface FeatureFlagContext {
   deploymentMode: DeploymentMode | null
   ingestionAvailable: boolean
   reasoningAvailable: boolean
+  inspectModeEnabled: boolean
+  chunksModeEnabled: boolean
+  askModeEnabled: boolean
 }
 
 const featureRegistry: Record<FeatureFlag, FeatureFlagDef> = {
@@ -52,6 +67,21 @@ const featureRegistry: Record<FeatureFlag, FeatureFlagDef> = {
     description: 'Reasoning trace tunnel (docling-agent ReasoningResult viewer)',
     isEnabled: (ctx) => ctx.reasoningAvailable,
   },
+  // 0.6.0 — Doc workspace mode flags (#210). Each one gates a tab in the
+  // doc workspace (#216 / E4) and triggers a router-level redirect when a
+  // disabled mode is requested via deep link. Defaults: enabled.
+  inspectMode: {
+    description: 'Doc workspace Inspect mode (tree + bbox debug view)',
+    isEnabled: (ctx) => ctx.inspectModeEnabled,
+  },
+  chunksMode: {
+    description: 'Doc workspace Chunks mode (editable chunkset + push to store)',
+    isEnabled: (ctx) => ctx.chunksModeEnabled,
+  },
+  askMode: {
+    description: 'Doc workspace Ask mode (agentic reasoning over the doc)',
+    isEnabled: (ctx) => ctx.askModeEnabled,
+  },
 }
 
 export const useFeatureFlagStore = defineStore('feature-flags', () => {
@@ -61,6 +91,11 @@ export const useFeatureFlagStore = defineStore('feature-flags', () => {
   const maxFileSizeMb = ref<number>(0)
   const ingestionAvailable = ref(false)
   const reasoningAvailable = ref(false)
+  // 0.6.0 — Doc workspace mode flags (#210). Default true so a backend
+  // that hasn't shipped the new fields yet behaves like the legacy one.
+  const inspectModeEnabled = ref(true)
+  const chunksModeEnabled = ref(true)
+  const askModeEnabled = ref(true)
   const appVersion = ref<string>(__APP_VERSION__)
   const loaded = ref(false)
   const error = ref<string | null>(null)
@@ -70,6 +105,9 @@ export const useFeatureFlagStore = defineStore('feature-flags', () => {
     deploymentMode: deploymentMode.value,
     ingestionAvailable: ingestionAvailable.value,
     reasoningAvailable: reasoningAvailable.value,
+    inspectModeEnabled: inspectModeEnabled.value,
+    chunksModeEnabled: chunksModeEnabled.value,
+    askModeEnabled: askModeEnabled.value,
   }))
 
   function isEnabled(flag: FeatureFlag): boolean {
@@ -87,6 +125,11 @@ export const useFeatureFlagStore = defineStore('feature-flags', () => {
       maxFileSizeMb.value = data.maxFileSizeMb ?? 0
       ingestionAvailable.value = data.ingestionAvailable ?? false
       reasoningAvailable.value = data.reasoningAvailable ?? false
+      // 0.6.0 — fall back to true when the field is missing so a frontend
+      // pointed at an older backend keeps every mode visible.
+      inspectModeEnabled.value = data.inspectModeEnabled ?? true
+      chunksModeEnabled.value = data.chunksModeEnabled ?? true
+      askModeEnabled.value = data.askModeEnabled ?? true
       appMaxFileSizeMb.value = maxFileSizeMb.value
       appMaxPageCount.value = maxPageCount.value
       if (data.version) appVersion.value = data.version
@@ -98,6 +141,19 @@ export const useFeatureFlagStore = defineStore('feature-flags', () => {
     }
   }
 
+  /**
+   * Convenience accessor for `resolveMode` — returns the three doc
+   * workspace mode flags as a `Record<DocMode, boolean>` so the routing
+   * guard does not need to know about the FeatureFlag union.
+   */
+  function modeFlags(): { ask: boolean; inspect: boolean; chunks: boolean } {
+    return {
+      ask: askModeEnabled.value,
+      inspect: inspectModeEnabled.value,
+      chunks: chunksModeEnabled.value,
+    }
+  }
+
   return {
     engine,
     deploymentMode,
@@ -105,10 +161,14 @@ export const useFeatureFlagStore = defineStore('feature-flags', () => {
     maxFileSizeMb,
     ingestionAvailable,
     reasoningAvailable,
+    inspectModeEnabled,
+    chunksModeEnabled,
+    askModeEnabled,
     appVersion,
     loaded,
     error,
     isEnabled,
+    modeFlags,
     load,
   }
 })

--- a/frontend/src/pages/DocsLibraryPage.vue
+++ b/frontend/src/pages/DocsLibraryPage.vue
@@ -1,14 +1,39 @@
 <template>
-  <ComingSoonShell
-    :title="t('comingSoon.title')"
-    :subtitle="t('comingSoon.subtitle.docsLibrary')"
-  />
+  <div>
+    <div v-if="showFlashAllModesDisabled" class="flash flash--warning" role="alert">
+      {{ t('flags.allModesDisabled') }}
+    </div>
+    <ComingSoonShell
+      :title="t('comingSoon.title')"
+      :subtitle="t('comingSoon.subtitle.docsLibrary')"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
-import { useI18n } from '../shared/i18n'
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 
+import { useI18n } from '../shared/i18n'
 import ComingSoonShell from '../shared/ui/ComingSoonShell.vue'
 
 const { t } = useI18n()
+const route = useRoute()
+
+// Surfaced when the router redirected here because every doc workspace
+// mode is feature-flagged off (#210). #211 will replace this with a
+// proper banner inside the library page.
+const showFlashAllModesDisabled = computed(() => route.query.reason === 'no-mode-enabled')
 </script>
+
+<style scoped>
+.flash {
+  margin: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #92400e;
+  background: #fef3c7;
+  border: 1px solid #fde68a;
+}
+</style>

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -33,6 +33,10 @@ const messages: Messages = {
     'breadcrumb.mode.inspect': 'Inspect',
     'breadcrumb.mode.chunks': 'Chunks',
 
+    // Feature flags (0.6.0 — #210)
+    'flags.allModesDisabled':
+      "Aucun mode (Ask / Inspect / Chunks) n'est activé pour ce déploiement. Contactez votre administrateur.",
+
     // Coming-soon placeholders (0.6.0 doc-centric routes — #207)
     'comingSoon.title': 'Bientôt disponible',
     'comingSoon.subtitle.docsLibrary':
@@ -332,6 +336,10 @@ const messages: Messages = {
     'breadcrumb.mode.ask': 'Ask',
     'breadcrumb.mode.inspect': 'Inspect',
     'breadcrumb.mode.chunks': 'Chunks',
+
+    // Feature flags (0.6.0 — #210)
+    'flags.allModesDisabled':
+      'No doc workspace mode (Ask / Inspect / Chunks) is enabled for this deployment. Contact your administrator.',
 
     // Coming-soon placeholders (0.6.0 doc-centric routes — #207)
     'comingSoon.title': 'Coming soon',

--- a/frontend/src/shared/routing/resolveMode.test.ts
+++ b/frontend/src/shared/routing/resolveMode.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import type { DocMode } from './modes'
+import { MODE_PRIORITY, resolveMode } from './resolveMode'
+
+const allEnabled: Record<DocMode, boolean> = { ask: true, chunks: true, inspect: true }
+const allDisabled: Record<DocMode, boolean> = { ask: false, chunks: false, inspect: false }
+
+describe('resolveMode', () => {
+  it('returns the requested mode when it is enabled', () => {
+    expect(resolveMode('ask', allEnabled)).toBe('ask')
+    expect(resolveMode('chunks', allEnabled)).toBe('chunks')
+    expect(resolveMode('inspect', allEnabled)).toBe('inspect')
+  })
+
+  it('falls back to the highest-priority enabled mode when the requested one is disabled', () => {
+    expect(resolveMode('chunks', { ...allEnabled, chunks: false })).toBe('ask')
+    expect(resolveMode('chunks', { ask: false, chunks: false, inspect: true })).toBe('inspect')
+  })
+
+  it('honours the priority order ask > chunks > inspect', () => {
+    expect(resolveMode(undefined, allEnabled)).toBe('ask')
+    expect(resolveMode(undefined, { ask: false, chunks: true, inspect: true })).toBe('chunks')
+    expect(resolveMode(undefined, { ask: false, chunks: false, inspect: true })).toBe('inspect')
+  })
+
+  it('returns null when no mode is enabled', () => {
+    expect(resolveMode('ask', allDisabled)).toBeNull()
+    expect(resolveMode(undefined, allDisabled)).toBeNull()
+  })
+
+  it('handles missing requested gracefully', () => {
+    expect(resolveMode(undefined, allEnabled)).toBe('ask')
+  })
+
+  it('exposes the priority in the right order', () => {
+    expect(MODE_PRIORITY).toEqual(['ask', 'chunks', 'inspect'])
+  })
+})

--- a/frontend/src/shared/routing/resolveMode.ts
+++ b/frontend/src/shared/routing/resolveMode.ts
@@ -1,0 +1,21 @@
+import { type DocMode } from './modes'
+
+/**
+ * Doc workspace mode resolution under feature flags (#210).
+ *
+ * The router consults this when a user opens `/docs/:id?mode=<mode>`:
+ *
+ *   - If the requested mode is enabled, return it.
+ *   - Otherwise, return the first enabled mode in `MODE_PRIORITY`.
+ *   - If no mode is enabled, return `null` (the router redirects to
+ *     the docs library with a flash message).
+ */
+export const MODE_PRIORITY: readonly DocMode[] = ['ask', 'chunks', 'inspect'] as const
+
+export function resolveMode(
+  requested: DocMode | undefined,
+  enabled: Record<DocMode, boolean>,
+): DocMode | null {
+  if (requested && enabled[requested]) return requested
+  return MODE_PRIORITY.find((m) => enabled[m]) ?? null
+}


### PR DESCRIPTION
## Type

- [x] Feature (\`feature/*\`)
- [ ] Bug fix (\`fix/*\`)
- [ ] Hotfix (\`hotfix/*\`)
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other: ___

## Summary

Surfaces three new doc-workspace mode flags on \`/api/health\` (\`inspectModeEnabled\` / \`chunksModeEnabled\` / \`askModeEnabled\`, defaults \`true\`), plus a router-level redirect so a deep link with a disabled mode gracefully rewrites to the first enabled one (priority \`ask\` > \`chunks\` > \`inspect\`). All three off → redirect to \`/docs?reason=no-mode-enabled\` with a flash banner.

The pure resolver \`resolveMode\` is unit-tested; the \`beforeEach\` guard wires it to the router. The flag store falls back to \`true\` for missing fields so a frontend pointed at an older backend behaves identically.

Tab-strip visibility (when E4 builds the workspace tabs in #216) and server-side write guards on chunks-edit endpoints (#205 follow-up) consume the same flags but are out of scope for this PR.

> **Stacked on #232 + #233 + #234 (#207, #208, #209).** Merge those first; this PR's diff will then narrow to just #210's commits.

## Related issues

Closes #210

## Checklist

- [x] Branch follows naming convention (\`feature/\`, \`fix/\`, \`hotfix/\`)
- [x] Commits follow [Conventional Commits](docs/git-workflow/commit-conventions.md)
- [x] Tests added/updated for the change
- [x] All tests pass (\`pytest tests/ -v\` + \`npm run test:run\`)
- [x] Linting passes (\`ruff check .\` + \`npx eslint src/\`)
- [ ] \`CHANGELOG.md\` updated under \`[Unreleased]\`
- [ ] Documentation updated if behavior changed
- [x] No secrets or credentials committed

## Screenshots / Evidence

Backend: 521 passed, 13 skipped (+1 health flag assertion).
Frontend: 246 passed (+9 across \`resolveMode.test.ts\` + flag store tests).
Design doc: \`docs/design/210-feature-flag-mode-gating.md\` (Status: Accepted).

Env vars added (defaults: \`true\`):
- \`INSPECT_MODE_ENABLED\`
- \`CHUNKS_MODE_ENABLED\`
- \`ASK_MODE_ENABLED\`