### PR TITLE
fix(nginx): configurable upload body size via NGINX_MAX_BODY_SIZE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@
 # Max upload file size in MB (default: 50, 0 = unlimited)
 # MAX_FILE_SIZE_MB=50
 
+# Nginx body size limit — nginx format (default: 200M, 0 = unlimited).
+# Must be >= MAX_FILE_SIZE_MB. Backend MAX_FILE_SIZE_MB is the effective arbiter.
+# NGINX_MAX_BODY_SIZE=200M
+
 # Max pages per PDF (default: 0 = unlimited). Set to 20 for HF Spaces.
 # MAX_PAGE_COUNT=0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Docling Studio will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.1] - 2026-04-30
+
+### Fixed
+
+- Nginx upload body cap raised from 5 MB to 200 MB (`NGINX_MAX_BODY_SIZE`, default `200M`); uploads larger than 5 MB no longer returned 413 before reaching the backend.
+
 ## [0.5.0] - 2026-04-28
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,11 @@ FROM python:3.12-slim AS base
 ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}
 
-# System deps: poppler (pdf2image), nginx
+# System deps: poppler (pdf2image), nginx, gettext-base (envsubst for nginx template)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     poppler-utils \
     nginx \
+    gettext-base \
     && rm -rf /var/lib/apt/lists/*
 
 # Python deps (common)
@@ -41,8 +42,8 @@ COPY document-parser/ .
 # Frontend static files
 COPY --from=frontend-build /build/dist /usr/share/nginx/html
 
-# Nginx config
-COPY nginx.conf /etc/nginx/sites-enabled/default
+# Nginx config (template — substituted at container start via envsubst)
+COPY nginx.conf.template /etc/nginx/sites-enabled/default.template
 
 # Non-root user
 RUN useradd --create-home --shell /bin/bash appuser
@@ -52,10 +53,11 @@ RUN mkdir -p /app/uploads /app/data && chown -R appuser:appuser /app
 
 ENV UPLOAD_DIR=/app/uploads
 ENV DB_PATH=/app/data/docling_studio.db
+ENV NGINX_MAX_BODY_SIZE=200M
 
 EXPOSE 3000
 
-CMD ["sh", "-c", "nginx && exec su appuser -c 'uvicorn main:app --host 127.0.0.1 --port 8000'"]
+CMD ["sh", "-c", "envsubst '${NGINX_MAX_BODY_SIZE}' < /etc/nginx/sites-enabled/default.template > /etc/nginx/sites-enabled/default && nginx && exec su appuser -c 'uvicorn main:app --host 127.0.0.1 --port 8000'"]
 
 # --- Remote: lightweight, delegates to Docling Serve ---
 FROM base AS remote

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ All configuration is done via environment variables. See [`.env.example`](.env.e
 | `BATCH_PAGE_SIZE` | `10` | Pages per batch (`0` = process all at once) |
 | `MAX_FILE_SIZE_MB` | `50` | Maximum upload file size in MB (`0` = unlimited) |
 | `MAX_PAGE_COUNT` | `0` | Maximum number of pages per document (`0` = unlimited) |
+| `NGINX_MAX_BODY_SIZE` | `200M` | Nginx request body limit — nginx format (`200M`, `0` = unlimited). Must be ≥ `MAX_FILE_SIZE_MB`. |
 | `RATE_LIMIT_RPM` | `100` | Max requests per minute per IP (`0` = disabled) |
 
 ## Upload Limits
@@ -218,8 +219,9 @@ Docling Studio enforces configurable limits on uploaded documents to protect the
 
 - **`MAX_FILE_SIZE_MB`** (default `50`) — rejects uploads exceeding this size. Validated at two levels: early `Content-Length` check and streaming byte count.
 - **`MAX_PAGE_COUNT`** (default `0` = unlimited) — rejects documents with more pages than allowed. Useful on shared instances or Hugging Face Spaces to cap processing time.
+- **`NGINX_MAX_BODY_SIZE`** (default `200M`) — nginx-level body cap, applied before the request reaches the backend. Defaults to `200M` so `MAX_FILE_SIZE_MB` is always the effective limit. Use nginx format (`50M`, `1G`, `0` for unlimited).
 
-Both limits are exposed in the `/api/health` endpoint so the frontend can display them to the user before upload. Set either to `0` to disable the corresponding check.
+Both application limits are exposed in the `/api/health` endpoint so the frontend can display them to the user before upload. Set either to `0` to disable the corresponding check.
 
 ## Ingestion Pipeline (opt-in)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,8 @@ services:
       context: ./frontend
     ports:
       - "3000:80"
+    environment:
+      NGINX_MAX_BODY_SIZE: ${NGINX_MAX_BODY_SIZE:-200M}
     depends_on:
       - document-parser
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,8 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+
+ENV NGINX_MAX_BODY_SIZE=200M
 
 EXPOSE 80

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 3000;
+    listen 80;
 
     root /usr/share/nginx/html;
     index index.html;
@@ -15,11 +15,11 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://127.0.0.1:8000;
+        proxy_pass http://document-parser:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_read_timeout 900s;
         proxy_send_timeout 900s;
-        client_max_body_size 5M;
+        client_max_body_size ${NGINX_MAX_BODY_SIZE};
     }
 }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 3000;
 
     root /usr/share/nginx/html;
     index index.html;
@@ -15,11 +15,11 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://document-parser:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_read_timeout 900s;
         proxy_send_timeout 900s;
-        client_max_body_size 5M;
+        client_max_body_size ${NGINX_MAX_BODY_SIZE};
     }
 }


### PR DESCRIPTION
## Type

- [ ] Feature (`feature/*`)
- [ ] Bug fix (`fix/*`)
- [x] Hotfix (`hotfix/*`)
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other: ___

## Summary

nginx was hard-capped at `client_max_body_size 5M`, causing 413 errors on uploads larger than 5 MB before the request even reached the FastAPI backend (which accepts up to `MAX_FILE_SIZE_MB`, default 50 MB). Both nginx configs are now templates substituted at container start via `envsubst`; `NGINX_MAX_BODY_SIZE` defaults to `200M` so the backend application limit is always the effective arbiter.

## Related issues

<!-- No prior ticket — bug discovered on production 0.5.0-local image -->

## Checklist

- [x] Branch follows naming convention (`feature/`, `fix/`, `hotfix/`)
- [x] Commits follow [Conventional Commits](docs/git-workflow/commit-conventions.md)
- [ ] Tests added/updated for the change
- [ ] All tests pass (`pytest tests/ -v` + `npm run test:run`)
- [ ] Linting passes (`ruff check .` + `npx eslint src/`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Documentation updated if behavior changed
- [x] No secrets or credentials committed

## Screenshots / Evidence

**Reproduce:** `docker run -p 3000:3000 ghcr.io/scub-france/docling-studio:0.5.0-local` → upload any PDF > 5 MB → 413.

**Fix:** `NGINX_MAX_BODY_SIZE` defaults to `200M`; override at runtime:
```bash
docker run -p 3000:3000 -e NGINX_MAX_BODY_SIZE=100M -e MAX_FILE_SIZE_MB=100 docling-studio:local
```