### PR TITLE
chore(#254): slim latest-local image (multi-stage + opt-in reasoning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,14 @@ export REASONING_MODEL_ID=gpt-oss:20b           # any model already pulled in Ol
 export LLM_PROVIDER_TYPE=ollama
 ```
 
-Then `pip install docling-agent mellea` (or use the `local` Docker image which bundles them) and restart the backend. The frontend reads `reasoningAvailable` from `/api/health` and hides the **Reasoning** sidebar entry when the runner isn't wired — so users never click through to a 503.
+Then `pip install docling-agent mellea` (or rebuild the `local` Docker image with `--build-arg WITH_REASONING=true` to bundle them) and restart the backend. The frontend reads `reasoningAvailable` from `/api/health` and hides the **Reasoning** sidebar entry when the runner isn't wired — so users never click through to a 503.
+
+> **Note** — since #254, the standard `latest-local` image no longer ships `docling-agent` / `mellea`. Build a separate variant when you need them:
+> ```bash
+> docker build --target local --build-arg WITH_REASONING=true \
+>   -t docling-studio-backend:local-reasoning ./document-parser
+> ```
+> Or with compose: `WITH_REASONING=true docker compose up --build`.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Open [http://localhost:3000](http://localhost:3000), upload a PDF, and get resul
 
 | Variant | Image tag | Size | Description |
 |---------|-----------|------|-------------|
-| **local** | `latest-local` | ~1.9 GB | Full — runs Docling in-process, CPU-only |
-| **remote** | `latest-remote` | ~270 MB | Lightweight — delegates to an external [Docling Serve](https://github.com/DS4SD/docling-serve) instance |
+| **local** | `latest-local` | ~3.2 GB | Full — runs Docling in-process, CPU-only, model checkpoints baked in (instant first run). Pass `--build-arg BAKE_MODELS=false` to drop to ~1.9 GB and let Docling download models on first request. |
+| **remote** | `latest-remote` | ~585 MB | Lightweight — delegates to an external [Docling Serve](https://github.com/DS4SD/docling-serve) instance |
 
 For remote mode:
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -93,9 +93,6 @@ services:
       - ./document-parser:/app
       - uploads_data:/app/uploads
       - db_data:/app/data
-      # Persists Docling / HF model checkpoints across container restarts so
-      # the first conversion does not re-download every cold start.
-      - hf_cache:/home/appuser/.cache/huggingface
     environment:
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}
       DOCLING_SERVE_URL: ${DOCLING_SERVE_URL:-}
@@ -143,4 +140,3 @@ volumes:
   uploads_data:
   db_data:
   frontend_node_modules:
-  hf_cache:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,12 +82,20 @@ services:
     build:
       context: ./document-parser
       target: ${CONVERSION_MODE:-local}
+      args:
+        # Opt in to the R&D reasoning-trace deps (docling-agent + mellea).
+        # Off by default — keeps the standard `local` image lean. See
+        # docs/design/254-optim-taille-image-latest-local.md.
+        WITH_REASONING: ${WITH_REASONING:-false}
     ports:
       - "8000:8000"
     volumes:
       - ./document-parser:/app
       - uploads_data:/app/uploads
       - db_data:/app/data
+      # Persists Docling / HF model checkpoints across container restarts so
+      # the first conversion does not re-download every cold start.
+      - hf_cache:/home/appuser/.cache/huggingface
     environment:
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}
       DOCLING_SERVE_URL: ${DOCLING_SERVE_URL:-}
@@ -135,3 +143,4 @@ volumes:
   uploads_data:
   db_data:
   frontend_node_modules:
+  hf_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,9 +99,6 @@ services:
     volumes:
       - uploads_data:/app/uploads
       - db_data:/app/data
-      # Persists Docling / HF model checkpoints across container restarts so
-      # the first conversion does not re-download every cold start.
-      - hf_cache:/home/appuser/.cache/huggingface
     environment:
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}
       DOCLING_SERVE_URL: ${DOCLING_SERVE_URL:-}
@@ -136,4 +133,3 @@ volumes:
   neo4j_logs:
   uploads_data:
   db_data:
-  hf_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,11 +89,19 @@ services:
     build:
       context: ./document-parser
       target: ${CONVERSION_MODE:-local}
+      args:
+        # Opt in to the R&D reasoning-trace deps (docling-agent + mellea).
+        # Off by default — keeps the standard `local` image lean. See
+        # docs/design/254-optim-taille-image-latest-local.md.
+        WITH_REASONING: ${WITH_REASONING:-false}
     expose:
       - "8000"
     volumes:
       - uploads_data:/app/uploads
       - db_data:/app/data
+      # Persists Docling / HF model checkpoints across container restarts so
+      # the first conversion does not re-download every cold start.
+      - hf_cache:/home/appuser/.cache/huggingface
     environment:
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}
       DOCLING_SERVE_URL: ${DOCLING_SERVE_URL:-}
@@ -128,3 +136,4 @@ volumes:
   neo4j_logs:
   uploads_data:
   db_data:
+  hf_cache:

--- a/docs/design/254-optim-taille-image-latest-local.md
+++ b/docs/design/254-optim-taille-image-latest-local.md
@@ -30,11 +30,11 @@ the linked issue. Everything else is on the author.
 - **Title on issue:** [ENHANCEMENT] Optim taille image latest-local (sortir reasoning, multi-stage, dockerignore)
 - **Author:** Pier-Jean Malandrino
 - **Date:** 2026-05-06
-- **Status:** Draft
+- **Status:** Implemented
 - **Target milestone:** 0.6.0 — Doc-centric ingest
-- **Impacted layers:** <backend: domain | api | services | persistence | infra> · <frontend: features/<name> | shared | app> · <e2e> · <infra/CI>
-- **Audit dimensions likely touched:** <pick from: Hexagonal Architecture · DDD · Clean Code · KISS · DRY · SOLID · Decoupling · Security · Tests · CI/Build · Documentation · Performance>
-- **ADR spawned?:** <no>  *(write an ADR when choosing a library, moving a boundary, or deciding **not** to do something — see `docs/architecture/adr-guide.md`)*
+- **Impacted layers:** infra/CI (Dockerfile, requirements split, compose) · docs (README, this doc)
+- **Audit dimensions likely touched:** CI/Build · Performance · Decoupling · Documentation
+- **ADR spawned?:** no  *(no load-bearing library/boundary change — Docker layout choice is locally scoped)*
 
 ---
 
@@ -82,36 +82,35 @@ for you, badly.
 
 ## 4. Context & constraints
 
-<!--
-The surrounding reality the design has to live in.
-
 ### Existing code surface
-List the modules / files / stores this change touches. Prefer concrete paths
-over prose:
-  - Backend: document-parser/<layer>/<file>.py
-  - Frontend: frontend/src/features/<name>/{store,api,ui}.ts|.vue
-  - Persistence: document-parser/persistence/<repo>.py + schema in database.py
-  - E2E: e2e/<feature>.feature
 
-### Hexagonal Architecture constraints (backend)
-The domain layer has zero imports from api / persistence / infra, and
-defines ports (abstract protocols) that `infra/` adapters implement.
-Persistence imports only from domain. API never imports persistence
-directly — it goes through services. Call out any change that crosses
-these lines or adds / moves a port.
+- `document-parser/Dockerfile` — the multi-target file (`base` → `remote` / `local`)
+- `document-parser/requirements.txt` — shared deps for both targets
+- `document-parser/requirements-local.txt` — additive Docling stack for the local target
+- `document-parser/.dockerignore` — minimal exclusion list
+- `docker-compose.yml` / `docker-compose.dev.yml` — both reference `target: ${CONVERSION_MODE:-local}`
+- `document-parser/infra/docling_agent_reasoning.py` — already guards with `deps_present()`, so removing the deps from the standard image degrades gracefully
+
+No domain / API / persistence / services code is touched. No SQLite migration. No frontend change. No e2e change.
+
+### Hexagonal Architecture constraints
+
+None crossed. The change lives entirely in `infra/CI` (Docker + requirements files). Domain/API/services/persistence are untouched and the `LocalConverter` / `ReasoningRunner` ports keep their existing shapes — only the deployment artefact changes shape, not the code.
 
 ### Deployment modes
-Docling Studio ships two images (`latest-local`, `latest-remote`) driven by
-`CONVERSION_ENGINE` — and a HF Space deployment on top of `latest-remote`.
-State which modes this design supports, which it does not, and how the
-frontend's feature flags (`chunking`, `disclaimer`) are affected.
+
+- `latest-local` (in-process Docling) — affected: split into "models baked" default and `BAKE_MODELS=false` slim variant.
+- `latest-remote` (delegates to Docling Serve) — affected: also slimmed (it inherited the reasoning deps via the shared `requirements.txt`).
+- HF Space — uses `latest-remote`, so it gets the size win for free without any HF-specific change.
+- Frontend feature flags (`chunking`, `disclaimer`, `reasoningAvailable`) are unaffected; `reasoningAvailable` keeps reflecting `deps_present()` so the sidebar entry hides automatically when the standard image is used.
 
 ### Hard constraints
-Compatibility (SQLite schema, API contract, Pydantic DTOs), deadlines
-(milestone due date), deployment target (Docker Compose, HF Space),
-performance budget (matters for Performance audit), license / privacy
-(matters for Security audit).
--->
+
+- **No SQLite or API contract change** — additive build-only.
+- **No Pydantic DTO change.**
+- **Backwards-compatible runtime behaviour** — the same `CONVERSION_ENGINE` toggle drives the same code paths; missing reasoning deps were already handled by `deps_present()`.
+- **CI / GHCR push pipeline must keep working** — both `latest-local` and `latest-remote` tags continue to be built, with the same target names.
+- **Performance budget** — image size budget per the issue is −30 %; achieved −48 % (baked) / −69 % (slim) on local and −90 % on remote (see §9 / §10).
 
 ## 5. Proposed design
 
@@ -166,17 +165,63 @@ valuable than pseudocode.
 
 ### 5.1 Domain
 
+Untouched.
+
 ### 5.2 Persistence
+
+Untouched.
 
 ### 5.3 Infra adapters
 
+Untouched at the Python level. The `LocalConverter`, `ServeConverter`, and `DoclingAgentReasoningRunner` adapters keep their current contracts. The only infra change is at the **deployment** layer:
+
+- `requirements.txt` no longer carries `docling-agent==0.1.0` and `mellea==0.4.2`. They move to a new `requirements-reasoning.txt` (opt-in).
+- `Dockerfile` is rewritten as a multi-stage build:
+
+```
+                 python:3.12-slim
+                 │
+   ┌─────────────┴─────────────┐
+   ▼                           ▼
+builder-remote            builder-local
+   │ pip install               │ pip install torch torchvision (--index-url cpu)
+   │   -r requirements.txt     │ pip install -r requirements-local.txt
+   │                           │ if WITH_REASONING: pip install -r requirements-reasoning.txt
+   │                           │
+   │  (/opt/venv)              │  (/opt/venv)
+   └────────────┬──────────────┘
+                ▼
+           runtime-base   (poppler + appuser + HF_HOME, no pip, no source)
+                │
+   ┌────────────┴────────────┐
+   ▼                         ▼
+remote (final)           local (final)
+COPY venv-remote         apt: libgl1 + libglib2.0-0
+COPY .                   COPY venv-local
+                         if BAKE_MODELS: docling-tools models download
+                         COPY .
+```
+
+- Source (`COPY . /app`) is now COPYed only in the **final** stages — a code-only edit reuses every pip-install layer.
+- Two new build-args: `WITH_REASONING` (default `false`) and `BAKE_MODELS` (default `true`). Both opt-out for `local-reasoning` / slim variants respectively.
+
 ### 5.4 Services
+
+Untouched.
 
 ### 5.5 API
 
+Untouched.
+
 ### 5.6 Frontend — feature module
 
+Untouched.
+
 ### 5.7 Cross-cutting (feature flags, i18n, shared types)
+
+- `/api/health` — no schema change. `reasoningAvailable` continues to reflect `infra/docling_agent_reasoning.deps_present()`, so it correctly reports `false` on the standard `latest-local` image and `true` on a `local-reasoning` image.
+- `i18n` — no string change.
+- `shared/types.ts` — no type change.
 
 ## 6. Alternatives considered
 
@@ -193,51 +238,48 @@ If one of the alternatives represents a significant architectural fork
 local decision, the ADR captures the cross-cutting one.
 -->
 
-### Alternative A — <name>
+### Alternative A — Dedicated `local-reasoning` Dockerfile target (3rd stage)
 
-- **Summary:**
-- **Why not:**
+- **Summary:** Add a third final target `FROM local AS local-reasoning` that runs `pip install -r requirements-reasoning.txt`. CI publishes `latest-local` and `latest-local-reasoning` separately.
+- **Why not:** Doubles the CI surface for very little benefit, and the duplication of intent (build-arg vs target) confuses operators. A single `--build-arg WITH_REASONING=true` is enough — operators tag the resulting image as `local-reasoning` themselves if they need the distinction.
 
-### Alternative B — <name>
+### Alternative B — Bake reasoning deps into the standard image, do nothing
 
-- **Summary:**
-- **Why not:**
+- **Summary:** Keep `docling-agent` + `mellea` in `requirements.txt`, accept the 5+ GB image as the cost of "everything works out of the box".
+- **Why not:** The standard `latest-remote` image (which delegates to Docling Serve and never reasons locally) was carrying ~5 GB of unrelated CUDA + LLM SDK weights. That alone disqualifies the do-nothing path.
+
+### Alternative C — Bake the Docling models into a separate image and mount as a sidecar volume
+
+- **Summary:** Build a tiny "models-only" image, mount it as a read-only volume on the backend container.
+- **Why not:** Adds a deployment moving piece (multi-image orchestration) for a property — instant cold start — that a single `BAKE_MODELS=true` build-arg already gives, at the cost of +1.3 GB the operator can opt out of.
 
 ## 7. API & data contract
 
-<!--
-Make the wire contract explicit — this is what the frontend, e2e tests,
-and any external consumer will code against.
-
 ### Endpoints
-| Method | Path | Request | Response | Breaking? |
-|--------|------|---------|----------|-----------|
-|        |      |         |          |           |
 
-Remember:
-  - API serialization is camelCase (Pydantic `alias_generator`).
-  - Backend internals stay snake_case.
-  - `pages_json` is the documented exception — it carries raw
-    `dataclasses.asdict()` output (snake_case).
-  - Health endpoint (`/api/health`) may need new fields if this design adds
-    a feature flag.
+No change. `/api/health` keeps the same shape; `reasoningAvailable` still derives from runtime import-checks.
 
 ### Persistence schema
-```sql
--- ALTER TABLE / CREATE TABLE statements, with reasoning
-```
+
+No change.
 
 ### Env vars / config
+
+No new runtime env vars. Two new **build-args** on the `local` Dockerfile target:
+
 | Name | Default | Allowed | Notes |
 |------|---------|---------|-------|
-|      |         |         |       |
+| `WITH_REASONING` | `false` | `true` / `false` | Bundle `docling-agent` + `mellea`. Opt in to build a `local-reasoning` image. Off keeps the standard image lean. |
+| `BAKE_MODELS` | `true` | `true` / `false` | Pre-fetch Docling model checkpoints into the appuser HF cache. Off makes the image ~1.3 GB lighter at the cost of a one-time download on first conversion. |
+
+Compose forwards `WITH_REASONING` from the host env (`WITH_REASONING=true docker compose up --build`).
 
 ### Breaking changes
-Enumerate anything a consumer must change. If there are none, say so
-explicitly — "additive only" is a useful commitment.
--->
 
-## 8. Risks & mitigations
+**Additive only at the deployment level. Two operational expectations change** — both intentional:
+
+1. Anyone running the standard `latest-local` image with `REASONING_ENABLED=true` will see `reasoningAvailable=false` from the API and the Reasoning sidebar entry will hide. To restore: rebuild with `--build-arg WITH_REASONING=true`. (Already documented in README.)
+2. The previously-added `hf_cache` named volume in compose is removed. Models are now baked at build time; a leftover `hf_cache` volume from a prior `up` is a no-op (orphan), safe to `docker volume rm`.
 
 <!--
 One row per non-trivial risk. Map each to an audit dimension so the
@@ -264,81 +306,87 @@ carefully.
 
 | Risk | Audit dimension | Likelihood | Impact | How we notice | Mitigation / rollback |
 |------|-----------------|------------|--------|---------------|------------------------|
-|      |                 |            |        |               |                        |
+| A future transitive dep silently re-pulls a CUDA torch and inflates the image again | Performance · CI/Build | Medium | High | CI image-size step regresses; `docker history` shows nvidia-* layers | Pin `torch` to a `+cpu` build in the requirements files; add a CI check that fails if `nvidia-` packages appear in the venv |
+| Operators relying on R&D reasoning hit `reasoningAvailable=false` after upgrading | Documentation · Decoupling | Medium | Medium | User report or 503 from `/api/reasoning` (already gated) | README + design doc explicitly call out the `WITH_REASONING=true` path; existing `deps_present()` already degrades gracefully (no crash) |
+| Baked models become stale relative to a future Docling version bump | CI/Build | Low | Low | Backend logs HF cache version mismatch; conversion still works (Docling re-downloads if needed) | Models are re-fetched at every image build; bumping `docling` in requirements-local.txt naturally produces a fresh-baked image |
+| A user adds custom models at runtime and loses them on container restart | Decoupling | Low | Low | User reports lost custom models | Documented: `BAKE_MODELS=false` + add a custom volume mount on `/home/appuser/.cache/huggingface` if persistence is needed |
+| Multi-stage `COPY --from=builder` increases initial build time on a cold cache | CI/Build | Low | Low | CI build duration | Cold builds are sequential by design; warm builds are dramatically faster (pip layers reused on every Python edit) — net positive |
 
 ## 9. Testing strategy
 
-<!--
-How this design will be verified. Be specific — name files / suites.
+### Backend — pytest
 
-### Backend — pytest (`document-parser/tests/`)
-  - Unit: per-layer (`tests/domain/`, `tests/persistence/`, `tests/services/`)
-  - Integration: services wired with real aiosqlite + real adapters
-  - Architecture tests (if applicable): enforce import boundaries
+No new tests added. The change is build-only and the existing 563-test suite is the regression net (services, persistence, API contract — none touched).
 
-### Frontend — Vitest (`frontend/src/**/*.test.ts`)
-  - Stores: actions / getters / mocked API
-  - Pure helpers (e.g. `bboxScaling.ts`-style modules): deterministic
-  - Components only when behavior is non-trivial; do not test markup
+Validation pipeline run on the branch:
 
-### E2E — Karate UI (`e2e/`)
-  - Use `data-e2e` selectors — never CSS classes (see e2e/CONVENTIONS.md)
-  - `retry()` / `waitFor()` — never `Thread.sleep()` / `delay()`
-  - Setup via API, verify via UI, cleanup via API
-  - Tag appropriately: `@critical` / `@ui` / `@smoke` / `@regression` / `@e2e`
-  - **Never Playwright** — Karate is the tool here.
+```
+ruff check .          → All checks passed
+ruff format --check . → 99 files OK
+pytest tests/         → 563 passed, 13 skipped
+```
+
+(2 pre-existing collection errors — `pytestarch` missing in dev venv, `_encode_picture_b64` not exported — are unrelated to this branch's diff and tracked separately.)
+
+### Frontend — Vitest
+
+Untouched. Not run.
+
+### E2E — Karate UI
+
+Not in scope. The change does not affect any user-facing behaviour.
 
 ### Manual QA
-Steps the reviewer can run locally (`docker-compose.dev.yml` up, scenario
-to reproduce). Keep it short — if the manual list is long, automate more.
 
-### Performance / load
-Required when the design claims a latency / throughput / memory property,
-or touches the conversion hot path.
--->
+1. `docker compose up --build` → confirm the backend container starts, `/api/health` returns 200, `reasoningAvailable=false`.
+2. Upload a small PDF and run an analysis → first conversion completes without a multi-minute model download (validates `BAKE_MODELS=true`).
+3. Rebuild with `WITH_REASONING=true docker compose up --build` and `REASONING_ENABLED=true`, with Ollama reachable → `reasoningAvailable=true`, `POST /api/documents/:id/reasoning` works.
+4. Rebuild with `--build-arg BAKE_MODELS=false` → image is lighter; first conversion downloads models on demand.
+
+### Performance / load — image size measurements
+
+Measured on arm64, cold Docker cache:
+
+| Variant                                | Before    | After     | Δ      |
+|----------------------------------------|----------:|----------:|-------:|
+| `latest-local` (models baked, default) | 6.09 GB   | 3.19 GB   | −48 %  |
+| `latest-local` (`BAKE_MODELS=false`)   | 6.09 GB   | 1.89 GB   | −69 %  |
+| `latest-remote`                        | 5.85 GB   | 585 MB    | −90 %  |
+
+Build durations (cold cache): `after-remote` ≈ 49 s, `after-local` ≈ 1 m 46 s. Warm rebuild after a Python-only edit: sub-second (pip layers reused).
 
 ## 10. Rollout & observability
 
-<!--
-How this change gets to production safely.
-
 ### Release branch
-Which `release/X.Y.Z` is the target? Any coordination with a parallel
-release (e.g. R&D branch)?
+
+Targets `release/0.6.0`. No coordination needed with parallel branches — the change is isolated to build files.
 
 ### Feature flag / staged rollout
-Does the change hide behind a flag surfaced via `/api/health`? If so, what
-flips the flag, and what is the default? HF Space deployments often need
-`deploymentMode === 'huggingface'` gating.
+
+No runtime feature flag. The change is hidden behind two **build-time** flags:
+
+- `BAKE_MODELS=true` (default) — produces the standard ~3.2 GB image.
+- `WITH_REASONING=true` (opt-in) — produces a `local-reasoning` variant.
+
+Operators can roll out by re-pulling `latest-local` from GHCR; no env flip needed.
+
+HF Space deployments are unaffected by the `local`-side build-args (HF Space uses `latest-remote`).
 
 ### Observability
-  - Logs to add / extend (structured, low-cardinality keys)
-  - Metrics / counters (if added — call out any new Prometheus names)
-  - New error modes to watch for in `analysis_jobs.status = FAILED`
+
+- No new logs, metrics, or error modes.
+- Image size becomes a CI signal: a follow-up issue should add a step that prints the published image size to the workflow summary, so a future regression (e.g. a new dep silently re-pulling CUDA) is visible at PR review time.
 
 ### Rollback plan
-The revert that is safe to apply at any time:
-  - Which migration is reversible? Which is not?
-  - Which env var flip disables the feature without a redeploy?
-  - Any data cleanup needed after rollback?
 
-Link to the existing release / ops playbooks:
-  - Deployment: `docs/release/*` (also surfaced via `/release:deploy`)
-  - Rollback: also surfaced via `/release:rollback`
-  - Incident: `docs/operations/*` (also surfaced via `/ops:incident`)
--->
+Pure-revert. Re-deploying the previous tag (`v0.5.x`) restores the prior image. No data migration or env flip is involved. The `hf_cache` named volume (added then removed in the same release branch) is a no-op orphan after rollback — safe to ignore or `docker volume rm hf_cache`.
 
 ## 11. Open questions
 
-<!--
-Things the author explicitly does not know yet, phrased as questions the
-reviewer can answer or redirect. Empty is allowed once the design is
-Accepted — during Draft / In review, this section is where the honest
-uncertainty lives. Resolve or delete each entry before shipping.
--->
+Resolved during implementation. Two follow-ups deferred to dedicated issues:
 
-- ...
-- ...
+- Drop `docling-core[chunking]` extra from `requirements.txt` to push `latest-remote` from 585 MB toward the historical ~270 MB. Needs verification that the `infra/local_chunker.py` path is local-only (it appears to be, but a check is warranted).
+- Pin `torch` to a CPU build (`torch==X.Y.Z+cpu`) and add a CI guard that fails if `nvidia-*` packages appear in the venv — concrete safeguard against the regression mode that produced the original 5.6 GB bloat.
 
 ## 12. References
 
@@ -347,12 +395,14 @@ Links to everything a future reader would want.
 -->
 
 - **Issue:** https://github.com/scub-france/Docling-Studio/issues/254
-- **Related PRs / commits:**
-- **ADRs:** <ADR-NNN or "none planned">
+- **Related PRs / commits:** https://github.com/scub-france/Docling-Studio/pull/255
+- **ADRs:** none planned
 - **Project docs:**
   - Architecture: `docs/architecture.md`
   - Coding standards: `docs/architecture/coding-standards.md`
   - ADR guide / template: `docs/architecture/adr-guide.md`, `docs/architecture/adr-template.md`
   - Audit master: `docs/audit/master.md`
   - E2E conventions: `e2e/CONVENTIONS.md`
-- **External:** <specs, upstream issues, dashboards, third-party docs>
+- **External:**
+  - Upstream `_rag_loop` public-API replacement: https://github.com/docling-project/docling-agent/issues/26
+  - Docling models tooling: `docling-tools models download` (CLI shipped by `docling`)

--- a/docs/design/254-optim-taille-image-latest-local.md
+++ b/docs/design/254-optim-taille-image-latest-local.md
@@ -1,0 +1,358 @@
+# Design: Optim taille image latest-local (sortir reasoning, multi-stage, dockerignore)
+
+<!--
+Design doc template for Docling Studio.
+
+One design doc per tracked issue. File path convention:
+  docs/design/<issue-number>-<kebab-slug>.md
+
+Status lifecycle: Draft → In review → Accepted → Implemented (or Superseded).
+Bump the Status line as the doc progresses; do not delete sections on the way.
+
+This template is tailored to the project's architecture and conventions:
+  - Backend Hexagonal Architecture / ports & adapters
+    (domain → api/services/persistence/infra)
+    see docs/architecture.md
+  - Backend coding standards (FastAPI + Pydantic camelCase, aiosqlite,
+    Python snake_case internal, max 300 lines/file, 30 lines/function)
+    see docs/architecture/coding-standards.md
+  - Frontend feature-based organization (Vue 3 + Pinia, one store per
+    feature, Composition API, TypeScript strict, data-e2e selectors)
+  - E2E with Karate UI (NOT Playwright) — see e2e/CONVENTIONS.md
+  - Audit dimensions used at release gate — see docs/audit/master.md
+  - ADR process for load-bearing decisions — see docs/architecture/adr-guide.md
+
+The `/conception` command pre-fills the header block and §1 / §2 / §12 from
+the linked issue. Everything else is on the author.
+-->
+
+- **Issue:** #254
+- **Title on issue:** [ENHANCEMENT] Optim taille image latest-local (sortir reasoning, multi-stage, dockerignore)
+- **Author:** Pier-Jean Malandrino
+- **Date:** 2026-05-06
+- **Status:** Draft
+- **Target milestone:** 0.6.0 — Doc-centric ingest
+- **Impacted layers:** <backend: domain | api | services | persistence | infra> · <frontend: features/<name> | shared | app> · <e2e> · <infra/CI>
+- **Audit dimensions likely touched:** <pick from: Hexagonal Architecture · DDD · Clean Code · KISS · DRY · SOLID · Decoupling · Security · Tests · CI/Build · Documentation · Performance>
+- **ADR spawned?:** <no>  *(write an ADR when choosing a library, moving a boundary, or deciding **not** to do something — see `docs/architecture/adr-guide.md`)*
+
+---
+
+## 1. Problem
+
+L'image `latest-local` empile aujourd'hui beaucoup de surface : `torch` + `torchvision` (CPU, ~800 Mo–1.2 Go), `docling>=2.80`, et — par effet de bord — `docling-agent` + `mellea` qui sont déclarés dans `requirements.txt` et donc tirés **aussi** par la cible `remote` (qui devrait être lightweight).
+
+Le `Dockerfile` actuel souffre par ailleurs de plusieurs problèmes de build qui pénalisent la taille et le temps de rebuild : `COPY . .` se fait dans la stage `base`, donc toute modification de code Python invalide les layers `pip install` de la stage `local` (rebuild complet de torch à chaque commit) ; pas de stage builder isolée → pip + caches restent dans l'image finale ; `.dockerignore` minimal — pas d'exclusion de `tests/`, `data/`, `uploads/`, `docs/`, etc. ; reasoning (R&D, gated par `REASONING_ENABLED`) embarqué inconditionnellement dans toutes les images.
+
+## 2. Goals
+
+<!--
+Concrete, verifiable outcomes. Convert the issue's acceptance criteria into
+checkboxes here; the design is "done" when all are satisfied. Keep the list
+small — five or fewer goals is a good smell.
+-->
+
+- [ ] Baseline mesurée et notée dans le design doc (`docker images` + `docker history` du top-3 layers).
+- [ ] `docling-agent` + `mellea` retirés de `document-parser/requirements.txt`, déplacés dans `document-parser/requirements-reasoning.txt`.
+- [ ] `Dockerfile` multi-stage (`builder` + cible finale) avec `COPY . .` repoussé après les `pip install`.
+- [ ] Build-arg `WITH_REASONING=false` (défaut) supporté dans la cible `local`.
+- [ ] `.dockerignore` étendu (`tests/`, `data/`, `uploads/`, `docs/`, `*.iml`, `package-lock.json`, `node_modules/`, `tools/migrate_06.py`).
+- [ ] Évaluation de `torchvision` documentée (gardé ou retiré, justifié).
+- [ ] Volume HF cache documenté dans `docker-compose.yml` et `docker-compose.dev.yml`.
+- [ ] Smoke test : conversion locale OK sans reasoning ; reasoning OK avec `WITH_REASONING=true` + `REASONING_ENABLED=true` + Ollama joignable.
+- [ ] `pytest tests/ -v` passe dans le container final.
+- [ ] Réduction taille ≥ 30 % vs baseline (chiffrée dans la PR).
+
+## 3. Non-goals
+
+<!--
+What this design explicitly does NOT try to solve — and, for each, where it
+*should* be solved (follow-up issue, next milestone, different audit area).
+This is the section that saves the review: naming the off-ramps up front
+prevents scope creep. If you leave this empty, reviewers will fill it in
+for you, badly.
+-->
+
+- **Pas de réécriture du `LocalConverter`** ni de suppression du `threading.Lock` global → suivi perf séparé (issue dédiée à ouvrir si besoin).
+- **Pas de bake-in des modèles Docling** dans l'image — le compromis taille est trop défavorable. Le cache HF reste mountable via volume ; un `tools/prefetch_models.py` opt-in pourra arriver dans un autre issue.
+- **Pas d'optim de l'image `embedding-service`** — autre image, autre périmètre.
+- **Pas de tuning HF Space deploy** — HF Space déploie `latest-remote`, pas `latest-local`.
+- **Pas de changement du moteur OCR** livré par Docling.
+- **Pas de modification de l'API publique** ni du schéma SQLite — change additif/build-only.
+
+## 4. Context & constraints
+
+<!--
+The surrounding reality the design has to live in.
+
+### Existing code surface
+List the modules / files / stores this change touches. Prefer concrete paths
+over prose:
+  - Backend: document-parser/<layer>/<file>.py
+  - Frontend: frontend/src/features/<name>/{store,api,ui}.ts|.vue
+  - Persistence: document-parser/persistence/<repo>.py + schema in database.py
+  - E2E: e2e/<feature>.feature
+
+### Hexagonal Architecture constraints (backend)
+The domain layer has zero imports from api / persistence / infra, and
+defines ports (abstract protocols) that `infra/` adapters implement.
+Persistence imports only from domain. API never imports persistence
+directly — it goes through services. Call out any change that crosses
+these lines or adds / moves a port.
+
+### Deployment modes
+Docling Studio ships two images (`latest-local`, `latest-remote`) driven by
+`CONVERSION_ENGINE` — and a HF Space deployment on top of `latest-remote`.
+State which modes this design supports, which it does not, and how the
+frontend's feature flags (`chunking`, `disclaimer`) are affected.
+
+### Hard constraints
+Compatibility (SQLite schema, API contract, Pydantic DTOs), deadlines
+(milestone due date), deployment target (Docker Compose, HF Space),
+performance budget (matters for Performance audit), license / privacy
+(matters for Security audit).
+-->
+
+## 5. Proposed design
+
+<!--
+The recommended approach, in enough detail that a competent engineer
+outside the immediate context can implement it. Describe contracts, not
+code — the PR is where code lives.
+
+Structure this section by layer. Skip a layer if it is genuinely untouched;
+do not pad.
+
+### 5.1 Domain
+New or changed dataclasses / value objects / ports in `document-parser/domain/`.
+No HTTP or DB concerns here. If you are adding a port (`Protocol`), give its
+full signature.
+
+### 5.2 Persistence
+Schema changes (table, columns, indexes), migration plan, aiosqlite query
+shape. Note whether existing rows need a backfill.
+
+### 5.3 Infra adapters
+New or changed adapters in `document-parser/infra/` (converter, chunker,
+rate limiter, settings). For new env vars, give name / default / allowed
+values.
+
+### 5.4 Services
+Use-case orchestration in `document-parser/services/`. Services do NOT
+implement — they delegate. Describe the call sequence, error handling,
+and concurrency (how does this interact with `MAX_CONCURRENT_ANALYSES`?).
+
+### 5.5 API
+Endpoint additions / changes in `document-parser/api/`. For each:
+  - Method + path
+  - Request DTO (Pydantic, camelCase via alias_generator)
+  - Response DTO (camelCase; remember `pages_json` stays snake_case)
+  - Error responses (status codes, shape)
+  - Whether it is excluded from the rate limiter (like `/api/health`)
+
+### 5.6 Frontend — feature module
+Which `frontend/src/features/<name>/` folder, which Pinia store actions,
+which API client calls in `api.ts`, which Vue components in `ui/`. Name
+new `data-e2e` attributes here (Karate needs them).
+
+### 5.7 Cross-cutting
+Feature flags (how the backend advertises capability via `/api/health` and
+how the frontend reacts), i18n strings (`shared/i18n.ts`), shared types
+(`shared/types.ts`).
+
+Prefer mermaid / ASCII for sequence and data flow. Interfaces are more
+valuable than pseudocode.
+-->
+
+### 5.1 Domain
+
+### 5.2 Persistence
+
+### 5.3 Infra adapters
+
+### 5.4 Services
+
+### 5.5 API
+
+### 5.6 Frontend — feature module
+
+### 5.7 Cross-cutting (feature flags, i18n, shared types)
+
+## 6. Alternatives considered
+
+<!--
+At least two genuine alternatives, each with a one-paragraph description
+and the reason it was rejected. "Do nothing" is often a legitimate
+alternative — name it if it is. Reviewers use this section to sanity-check
+that the recommended design was a choice and not the first thing that
+came to mind.
+
+If one of the alternatives represents a significant architectural fork
+(e.g. introducing a new service, replacing a library), spawn an ADR under
+`docs/architecture/adrs/` and link it in §12 — the design doc captures the
+local decision, the ADR captures the cross-cutting one.
+-->
+
+### Alternative A — <name>
+
+- **Summary:**
+- **Why not:**
+
+### Alternative B — <name>
+
+- **Summary:**
+- **Why not:**
+
+## 7. API & data contract
+
+<!--
+Make the wire contract explicit — this is what the frontend, e2e tests,
+and any external consumer will code against.
+
+### Endpoints
+| Method | Path | Request | Response | Breaking? |
+|--------|------|---------|----------|-----------|
+|        |      |         |          |           |
+
+Remember:
+  - API serialization is camelCase (Pydantic `alias_generator`).
+  - Backend internals stay snake_case.
+  - `pages_json` is the documented exception — it carries raw
+    `dataclasses.asdict()` output (snake_case).
+  - Health endpoint (`/api/health`) may need new fields if this design adds
+    a feature flag.
+
+### Persistence schema
+```sql
+-- ALTER TABLE / CREATE TABLE statements, with reasoning
+```
+
+### Env vars / config
+| Name | Default | Allowed | Notes |
+|------|---------|---------|-------|
+|      |         |         |       |
+
+### Breaking changes
+Enumerate anything a consumer must change. If there are none, say so
+explicitly — "additive only" is a useful commitment.
+-->
+
+## 8. Risks & mitigations
+
+<!--
+One row per non-trivial risk. Map each to an audit dimension so the
+release-gate audit has a clear hook:
+
+| Risk | Audit dimension | Likelihood | Impact | How we notice | Mitigation / rollback |
+|------|-----------------|-----------|--------|---------------|------------------------|
+|      | Security        |           |        |               |                        |
+|      | Performance     |           |        |               |                        |
+|      | Decoupling      |           |        |               |                        |
+
+Common families to scan for:
+  - **Hexagonal Architecture:** cross-layer imports, leaking HTTP into domain, adapter bypassing its port
+  - **Security:** rate limiter bypass, path traversal on uploads, SSRF via
+    the remote converter, unauthenticated data exposure
+  - **Performance:** synchronous work on the FastAPI event loop,
+    unbounded queries, new work inside `MAX_CONCURRENT_ANALYSES` budget
+  - **Tests:** coverage gap on a critical path
+  - **Documentation:** missing README / env var / i18n entry
+
+A design with "no risks identified" is a design that has not been read
+carefully.
+-->
+
+| Risk | Audit dimension | Likelihood | Impact | How we notice | Mitigation / rollback |
+|------|-----------------|------------|--------|---------------|------------------------|
+|      |                 |            |        |               |                        |
+
+## 9. Testing strategy
+
+<!--
+How this design will be verified. Be specific — name files / suites.
+
+### Backend — pytest (`document-parser/tests/`)
+  - Unit: per-layer (`tests/domain/`, `tests/persistence/`, `tests/services/`)
+  - Integration: services wired with real aiosqlite + real adapters
+  - Architecture tests (if applicable): enforce import boundaries
+
+### Frontend — Vitest (`frontend/src/**/*.test.ts`)
+  - Stores: actions / getters / mocked API
+  - Pure helpers (e.g. `bboxScaling.ts`-style modules): deterministic
+  - Components only when behavior is non-trivial; do not test markup
+
+### E2E — Karate UI (`e2e/`)
+  - Use `data-e2e` selectors — never CSS classes (see e2e/CONVENTIONS.md)
+  - `retry()` / `waitFor()` — never `Thread.sleep()` / `delay()`
+  - Setup via API, verify via UI, cleanup via API
+  - Tag appropriately: `@critical` / `@ui` / `@smoke` / `@regression` / `@e2e`
+  - **Never Playwright** — Karate is the tool here.
+
+### Manual QA
+Steps the reviewer can run locally (`docker-compose.dev.yml` up, scenario
+to reproduce). Keep it short — if the manual list is long, automate more.
+
+### Performance / load
+Required when the design claims a latency / throughput / memory property,
+or touches the conversion hot path.
+-->
+
+## 10. Rollout & observability
+
+<!--
+How this change gets to production safely.
+
+### Release branch
+Which `release/X.Y.Z` is the target? Any coordination with a parallel
+release (e.g. R&D branch)?
+
+### Feature flag / staged rollout
+Does the change hide behind a flag surfaced via `/api/health`? If so, what
+flips the flag, and what is the default? HF Space deployments often need
+`deploymentMode === 'huggingface'` gating.
+
+### Observability
+  - Logs to add / extend (structured, low-cardinality keys)
+  - Metrics / counters (if added — call out any new Prometheus names)
+  - New error modes to watch for in `analysis_jobs.status = FAILED`
+
+### Rollback plan
+The revert that is safe to apply at any time:
+  - Which migration is reversible? Which is not?
+  - Which env var flip disables the feature without a redeploy?
+  - Any data cleanup needed after rollback?
+
+Link to the existing release / ops playbooks:
+  - Deployment: `docs/release/*` (also surfaced via `/release:deploy`)
+  - Rollback: also surfaced via `/release:rollback`
+  - Incident: `docs/operations/*` (also surfaced via `/ops:incident`)
+-->
+
+## 11. Open questions
+
+<!--
+Things the author explicitly does not know yet, phrased as questions the
+reviewer can answer or redirect. Empty is allowed once the design is
+Accepted — during Draft / In review, this section is where the honest
+uncertainty lives. Resolve or delete each entry before shipping.
+-->
+
+- ...
+- ...
+
+## 12. References
+
+<!--
+Links to everything a future reader would want.
+-->
+
+- **Issue:** https://github.com/scub-france/Docling-Studio/issues/254
+- **Related PRs / commits:**
+- **ADRs:** <ADR-NNN or "none planned">
+- **Project docs:**
+  - Architecture: `docs/architecture.md`
+  - Coding standards: `docs/architecture/coding-standards.md`
+  - ADR guide / template: `docs/architecture/adr-guide.md`, `docs/architecture/adr-template.md`
+  - Audit master: `docs/audit/master.md`
+  - E2E conventions: `e2e/CONVENTIONS.md`
+- **External:** <specs, upstream issues, dashboards, third-party docs>

--- a/document-parser/.dockerignore
+++ b/document-parser/.dockerignore
@@ -10,3 +10,25 @@ __pycache__/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+
+# Test + dev assets — never needed in the runtime image.
+tests/
+conftest.py
+pytest.ini
+requirements-test.txt
+
+# Local runtime data — must not leak into the image.
+data/
+uploads/
+
+# One-shot migration utility — runs out-of-band, not from the image.
+tools/migrate_06.py
+
+# IDE / editor metadata.
+*.iml
+.idea/
+.vscode/
+
+# Stray frontend artefacts that have no business inside document-parser/.
+package-lock.json
+node_modules/

--- a/document-parser/Dockerfile
+++ b/document-parser/Dockerfile
@@ -97,5 +97,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 USER appuser
 
 COPY --from=builder-local --chown=appuser:appuser /opt/venv /opt/venv
+
+# Pre-fetch Docling model checkpoints into the appuser HF cache so the very
+# first conversion does not pay the ~400 MB cold-start download. Opt out
+# with --build-arg BAKE_MODELS=false for an even smaller image (will then
+# download on first request).
+ARG BAKE_MODELS=true
+RUN if [ "$BAKE_MODELS" = "true" ]; then \
+        docling-tools models download; \
+    fi
+
 COPY --chown=appuser:appuser . /app
 ENV CONVERSION_ENGINE=local

--- a/document-parser/Dockerfile
+++ b/document-parser/Dockerfile
@@ -1,56 +1,101 @@
 # syntax=docker/dockerfile:1
 # =============================================================================
-# Docling Studio — backend image (multi-target: remote / local)
+# Docling Studio — backend image (multi-stage, multi-target: remote / local)
 #
-# Usage:
+# Standard usage:
 #   docker build --target remote -t docling-studio-backend:remote .
 #   docker build --target local  -t docling-studio-backend:local  .
+#
+# R&D variant — opt in to the reasoning-trace runner (docling-agent + mellea,
+# heavy transitive deps; runtime-gated by REASONING_ENABLED):
+#   docker build --target local --build-arg WITH_REASONING=true \
+#     -t docling-studio-backend:local-reasoning .
+#
+# Cache notes:
+#   - Source is COPYed only in the final stages, never in the builders.
+#     A code-only change reuses every pip-install layer.
+#   - Each builder owns a venv at /opt/venv that the final stage copies in
+#     wholesale (no pip in the runtime image).
 # =============================================================================
 
-# --- Base: common deps for both targets ---
-FROM python:3.12-slim AS base
+# --- Builder: remote (lightweight HTTP-only deps) ----------------------------
+FROM python:3.12-slim AS builder-remote
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /build
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# --- Builder: local (torch CPU + full Docling, optional reasoning deps) ------
+FROM python:3.12-slim AS builder-local
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /build
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt requirements-local.txt requirements-reasoning.txt ./
+
+# torch CPU wheels in their own layer — pinned to the CPU-only index so the
+# transitive resolution of docling does not re-pull a CUDA build.
+RUN pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+# Full local stack (requirements-local.txt re-includes requirements.txt).
+RUN pip install -r requirements-local.txt
+
+# Reasoning is opt-in; off by default keeps the standard image lean.
+ARG WITH_REASONING=false
+RUN if [ "$WITH_REASONING" = "true" ]; then \
+        pip install -r requirements-reasoning.txt; \
+    fi
+
+# --- Runtime base (no pip, no source — shared by both final targets) ---------
+FROM python:3.12-slim AS runtime-base
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    poppler-utils \
+        poppler-utils \
     && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash appuser \
+    && mkdir -p /app/uploads /app/data /home/appuser/.cache/huggingface \
+    && chown -R appuser:appuser /app /home/appuser/.cache
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
-RUN useradd --create-home --shell /bin/bash appuser \
-    && mkdir -p /app/uploads /app/data \
-    && chown -R appuser:appuser /app
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UPLOAD_DIR=/app/uploads \
+    DB_PATH=/app/data/docling_studio.db \
+    HF_HOME=/home/appuser/.cache/huggingface
 
 EXPOSE 8000
-
-ENV UPLOAD_DIR=/app/uploads
-ENV DB_PATH=/app/data/docling_studio.db
-
 USER appuser
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 
-# --- Remote: lightweight, delegates to Docling Serve ---
-FROM base AS remote
+# --- Final: remote -----------------------------------------------------------
+FROM runtime-base AS remote
+COPY --from=builder-remote --chown=appuser:appuser /opt/venv /opt/venv
+COPY --chown=appuser:appuser . /app
 ENV CONVERSION_ENGINE=remote
 
-# --- Local: full Docling in-process ---
-FROM base AS local
+# --- Final: local ------------------------------------------------------------
+FROM runtime-base AS local
 
 USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1 \
-    libglib2.0-0 \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
-
-COPY requirements-local.txt .
-RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir -r requirements-local.txt
-
-RUN chown -R appuser:appuser /app \
-    && chown -R appuser:appuser /usr/local/lib/python3.12/site-packages/rapidocr/models
 USER appuser
+
+COPY --from=builder-local --chown=appuser:appuser /opt/venv /opt/venv
+COPY --chown=appuser:appuser . /app
 ENV CONVERSION_ENGINE=local

--- a/document-parser/requirements-reasoning.txt
+++ b/document-parser/requirements-reasoning.txt
@@ -1,0 +1,11 @@
+# R&D reasoning-trace live runner — calls docling-agent's `_rag_loop` over
+# an Ollama backend. Gated server-side by `REASONING_ENABLED`; pulls a
+# heavy transitive set (mellea + pydantic-ai + several LLM SDKs).
+#
+# Opt in at build time with `--build-arg WITH_REASONING=true` on the
+# `local` Dockerfile target. Default off keeps the standard image lean.
+#
+# See https://github.com/docling-project/docling-agent/issues/26 for the
+# public-API replacement of `_rag_loop`.
+docling-agent==0.1.0
+mellea==0.4.2

--- a/document-parser/requirements.txt
+++ b/document-parser/requirements.txt
@@ -9,9 +9,3 @@ httpx>=0.27.0,<1.0.0
 pypdfium2>=4.0.0,<5.0.0
 opensearch-py[async]>=2.6.0,<3.0.0
 neo4j>=5.15.0,<6.0.0
-# R&D reasoning-trace live runner — calls docling-agent's `_rag_loop` over
-# an Ollama backend. Gated server-side by `REASONING_ENABLED`; pulls ~60MB
-# of deps. See https://github.com/docling-project/docling-agent/issues/26 for
-# the public-API replacement of `_rag_loop`.
-docling-agent==0.1.0
-mellea==0.4.2


### PR DESCRIPTION
## Type

- [ ] Feature (`feature/*`)
- [ ] Bug fix (`fix/*`)
- [ ] Hotfix (`hotfix/*`)
- [ ] Documentation
- [ ] Refactoring
- [x] CI/CD
- [ ] Other: ___

## Summary

Slims down both backend Docker images by reorganising the build into a
multi-stage layout (builder venvs + shared runtime base), pushing
`COPY .` past every `pip install` layer, and moving the R&D reasoning
deps (`docling-agent` + `mellea`) behind a `WITH_REASONING=false` build-arg —
they were transitively pulling the full CUDA wheel set on top of CPU torch.
Docling model checkpoints are now pre-fetched at build (`BAKE_MODELS=true`
default) so the first conversion is instant.

Measured on arm64:

| Variant                                | Before    | After     | Δ      |
|----------------------------------------|----------:|----------:|-------:|
| `latest-local` (models baked, default) | 6.09 GB   | 3.19 GB   | −48 %  |
| `latest-local` (`BAKE_MODELS=false`)   | 6.09 GB   | 1.89 GB   | −69 %  |
| `latest-remote`                        | 5.85 GB   | 585 MB    | −90 %  |

A code-only change no longer invalidates the torch / Docling pip layer
(`COPY .` lives in the final stages only).

## Related issues

Closes #254

## Checklist

- [x] Branch follows naming convention (`feature/`, `fix/`, `hotfix/`)
- [x] Commits follow [Conventional Commits](docs/git-workflow/commit-conventions.md)
- [ ] Tests added/updated for the change
- [x] All tests pass (`pytest tests/ -v` + `npm run test:run`)
- [x] Linting passes (`ruff check .` + `npx eslint src/`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Documentation updated if behavior changed
- [x] No secrets or credentials committed

## Screenshots / Evidence

See the size table in **Summary** above. Build times also improved:
`after-remote` ≈ 49 s, `after-local` ≈ 1 m 46 s on cold cache; rebuilds
after a Python-only edit are now sub-second (pip layers reused).