### PR TITLE
feat(#268): Strategy popover — inline rechunk from the Chunk view

### DIFF
--- a/e2e/ui/src/test/resources/documents/doc-strategy-popover.feature
+++ b/e2e/ui/src/test/resources/documents/doc-strategy-popover.feature
@@ -1,0 +1,55 @@
+@ui @regression
+Feature: UI — Strategy popover rechunks from the Chunk view (#268)
+
+  # The Strategy button in the Chunk panel opens a popover with the
+  # chunker options. Apply triggers POST /rechunk and replaces the
+  # canonical chunkset. Setup is API-driven; the UI portion only
+  # exercises the popover form.
+
+  Background:
+    * url baseUrl
+
+  Scenario: Open Strategy, change max tokens, apply, chunks refresh
+    * def upload = call read('classpath:common/helpers/upload.feature') { file: 'small.pdf' }
+    * def docId = upload.docId
+
+    Given url baseUrl
+    And path '/api/analyses'
+    And request { documentId: '#(docId)', chunkingOptions: { chunkerType: 'hybrid', maxTokens: 512, mergePeers: true, repeatTableHeader: true } }
+    When method POST
+    Then status 200
+    * def analysisId = response.id
+
+    Given url baseUrl
+    And path '/api/analyses', analysisId
+    And retry until response.status == 'COMPLETED' || response.status == 'FAILED'
+    When method GET
+    Then status 200
+    And match response.status == 'COMPLETED'
+
+    * driver uiBaseUrl + '/docs/' + docId + '?mode=chunk'
+    * waitFor('[data-e2e=chunk-tab]')
+    * waitFor('[data-e2e=chunks-panel]')
+
+    # Snapshot the current count of cards before rechunking.
+    * def before = karate.sizeOf(locateAll('[data-e2e=chunks-panel-list] li'))
+    * assert before > 0
+
+    # Open Strategy → form visible.
+    * click('[data-e2e=strategy-btn]')
+    * waitFor('[data-e2e=strategy-popover]')
+    * waitFor('[data-e2e=strategy-form]')
+
+    # Change max tokens to a smaller value to force a new chunking pass.
+    * driver.input('[data-e2e=strategy-max-tokens]', '128')
+
+    # Apply → no manual edits so no confirm step; popover closes.
+    * click('[data-e2e=strategy-apply]')
+    * retry().until(!exists('[data-e2e=strategy-popover]'))
+
+    # Chunks panel still renders (smaller max_tokens should usually
+    # produce equal-or-more chunks; we just assert presence).
+    * waitFor('[data-e2e=chunks-panel-list]')
+    * assert karate.sizeOf(locateAll('[data-e2e=chunks-panel-list] li')) > 0
+
+    * call read('classpath:common/helpers/cleanup-by-name.feature') { filename: 'small.pdf' }

--- a/frontend/src/features/chunks/store.test.ts
+++ b/frontend/src/features/chunks/store.test.ts
@@ -13,7 +13,12 @@ vi.mock('./api', () => ({
   pushChunksToStore: vi.fn(),
 }))
 
+vi.mock('../document/api', () => ({
+  rechunkDocument: vi.fn(),
+}))
+
 import * as api from './api'
+import * as documentApi from '../document/api'
 
 const makeChunk = (id: string, text = 'text', overrides: Record<string, unknown> = {}) => ({
   id,
@@ -155,5 +160,54 @@ describe('useChunksStore', () => {
 
     expect(jobId).toBeNull()
     expect(store.error).toBe('network')
+  })
+
+  // ---------------------------------------------------------------------------
+  // rechunk + hasManualEdits (#268)
+  // ---------------------------------------------------------------------------
+
+  it('rechunk — replaces chunks with the API response and returns true', async () => {
+    const next = [makeChunk('c1'), makeChunk('c2')]
+    documentApi.rechunkDocument.mockResolvedValue(next)
+    const store = useChunksStore()
+    store.chunks = [makeChunk('old')]
+
+    const ok = await store.rechunk('d1', { chunkerType: 'hybrid', maxTokens: 256 })
+
+    expect(documentApi.rechunkDocument).toHaveBeenCalledWith('d1', {
+      chunkerType: 'hybrid',
+      maxTokens: 256,
+    })
+    expect(ok).toBe(true)
+    expect(store.chunks.map((c) => c.id)).toEqual(['c1', 'c2'])
+    expect(store.rechunking).toBe(false)
+  })
+
+  it('rechunk — returns false on failure and keeps existing chunks', async () => {
+    documentApi.rechunkDocument.mockRejectedValue(new Error('boom'))
+    const store = useChunksStore()
+    store.chunks = [makeChunk('old')]
+
+    const ok = await store.rechunk('d1')
+
+    expect(ok).toBe(false)
+    expect(store.error).toBe('boom')
+    expect(store.chunks.map((c) => c.id)).toEqual(['old'])
+    expect(store.rechunking).toBe(false)
+  })
+
+  it('hasManualEdits — false when updatedAt equals createdAt for every chunk', () => {
+    const store = useChunksStore()
+    store.chunks = [makeChunk('c1'), makeChunk('c2')]
+    expect(store.hasManualEdits).toBe(false)
+  })
+
+  it('hasManualEdits — true as soon as one chunk has been touched', () => {
+    const store = useChunksStore()
+    store.chunks = [
+      makeChunk('c1'),
+      makeChunk('c2', 'edited', { updatedAt: '2025-02-01T00:00:00Z' }),
+    ]
+    expect(store.hasManualEdits).toBe(true)
   })
 })

--- a/frontend/src/features/chunks/store.ts
+++ b/frontend/src/features/chunks/store.ts
@@ -1,12 +1,14 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { DocChunk, ChunkDiff } from '../../shared/types'
+import { rechunkDocument, type RechunkOptions } from '../document/api'
 import * as api from './api'
 
 export const useChunksStore = defineStore('chunks', () => {
   const chunks = ref<DocChunk[]>([])
   const loading = ref(false)
   const saving = ref(false)
+  const rechunking = ref(false)
   const diffing = ref(false)
   const diff = ref<ChunkDiff[]>([])
   const error = ref<string | null>(null)
@@ -130,6 +132,34 @@ export const useChunksStore = defineStore('chunks', () => {
     }
   }
 
+  /**
+   * Rechunk the canonical chunkset with the given options (#268). The
+   * backend replaces the whole chunkset and returns the new list; the
+   * store overwrites `chunks` so the UI reflects the new layout in
+   * one render pass.
+   */
+  async function rechunk(docId: string, options?: RechunkOptions): Promise<boolean> {
+    rechunking.value = true
+    error.value = null
+    try {
+      chunks.value = await rechunkDocument(docId, options)
+      return true
+    } catch (e) {
+      error.value = (e as Error).message || 'Failed to rechunk'
+      console.error('Failed to rechunk', e)
+      return false
+    } finally {
+      rechunking.value = false
+    }
+  }
+
+  /** True when at least one chunk has been hand-edited (#264 — chunks
+   *  where `updatedAt !== createdAt` are flagged with the `edited`
+   *  badge). The Strategy popover uses this to gate a confirm step. */
+  const hasManualEdits = computed(() =>
+    chunks.value.some((c) => c.updatedAt && c.createdAt && c.updatedAt !== c.createdAt),
+  )
+
   async function loadDiff(docId: string, store: string): Promise<void> {
     diffing.value = true
     error.value = null
@@ -161,13 +191,16 @@ export const useChunksStore = defineStore('chunks', () => {
   return {
     chunks,
     chunksOnPage,
+    hasManualEdits,
     loading,
     saving,
+    rechunking,
     diffing,
     diff,
     error,
     clearError,
     load,
+    rechunk,
     updateText,
     updateTitle,
     merge,

--- a/frontend/src/features/chunks/ui/ChunksPanel.vue
+++ b/frontend/src/features/chunks/ui/ChunksPanel.vue
@@ -14,13 +14,22 @@
       <button
         type="button"
         class="strategy-btn"
-        :disabled="true"
-        :title="t('linked.strategySoon')"
+        :disabled="chunksStore.rechunking"
+        :title="t('chunk.strategy')"
         data-e2e="strategy-btn"
+        @click="openStrategy"
       >
-        ⚙ {{ t('linked.strategy') }}
+        ⚙ {{ t('chunk.strategy') }}
       </button>
     </header>
+
+    <StrategyPopover
+      :open="strategyOpen"
+      :has-manual-edits="chunksStore.hasManualEdits"
+      :rechunking="chunksStore.rechunking"
+      @close="strategyOpen = false"
+      @apply="onApplyStrategy"
+    />
 
     <div v-if="chunksStore.loading" class="chunks-panel-state">
       <span class="spinner" />
@@ -84,11 +93,13 @@
  * The Strategy button is rendered as disabled with a tooltip until
  * T7 (#268) wires the rechunk popover.
  */
-import { computed, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { DocChunk } from '../../../shared/types'
+import type { RechunkOptions } from '../../document/api'
 import { useI18n } from '../../../shared/i18n'
 import { colorFor } from '../../document/elementColors'
 import { useChunksStore } from '../store'
+import StrategyPopover from './StrategyPopover.vue'
 
 const props = defineProps<{
   docId: string
@@ -106,6 +117,19 @@ const { t } = useI18n()
 const chunksStore = useChunksStore()
 
 const pageChunks = computed<DocChunk[]>(() => chunksStore.chunksOnPage(props.currentPage))
+
+// Strategy popover (#268) — anchored inline; the chunks store handles
+// the actual rechunk call so its state survives popover dismissal.
+const strategyOpen = ref(false)
+
+function openStrategy(): void {
+  strategyOpen.value = true
+}
+
+async function onApplyStrategy(options: RechunkOptions): Promise<void> {
+  const ok = await chunksStore.rechunk(props.docId, options)
+  if (ok) strategyOpen.value = false
+}
 
 const cardRefs = new Map<string, HTMLElement>()
 

--- a/frontend/src/features/chunks/ui/StrategyPopover.vue
+++ b/frontend/src/features/chunks/ui/StrategyPopover.vue
@@ -1,0 +1,369 @@
+<template>
+  <div
+    v-if="open"
+    class="strategy-popover-backdrop"
+    data-e2e="strategy-backdrop"
+    @click.self="onClose"
+  >
+    <div
+      class="strategy-popover"
+      role="dialog"
+      :aria-label="t('strategy.title')"
+      data-e2e="strategy-popover"
+    >
+      <header class="strategy-popover-header">
+        <h2 class="strategy-popover-title">{{ t('strategy.title') }}</h2>
+        <button
+          type="button"
+          class="strategy-close"
+          :aria-label="t('strategy.close')"
+          @click="onClose"
+        >
+          ×
+        </button>
+      </header>
+
+      <!-- Form -->
+      <div v-if="step === 'form'" class="strategy-popover-body" data-e2e="strategy-form">
+        <p class="strategy-popover-hint">{{ t('strategy.hint') }}</p>
+        <div class="strategy-field">
+          <label class="strategy-label" for="strategy-chunker-type">{{
+            t('strategy.chunkerType')
+          }}</label>
+          <select
+            id="strategy-chunker-type"
+            v-model="draft.chunkerType"
+            class="strategy-select"
+            data-e2e="strategy-chunker-type"
+          >
+            <option value="hybrid">hybrid</option>
+            <option value="hierarchical">hierarchical</option>
+          </select>
+        </div>
+
+        <div class="strategy-field">
+          <label class="strategy-label" for="strategy-max-tokens">{{
+            t('strategy.maxTokens')
+          }}</label>
+          <input
+            id="strategy-max-tokens"
+            v-model.number="draft.maxTokens"
+            type="number"
+            min="64"
+            max="8192"
+            class="strategy-input"
+            data-e2e="strategy-max-tokens"
+          />
+          <span class="strategy-hint">{{ t('strategy.maxTokensHint') }}</span>
+        </div>
+
+        <div v-if="draft.chunkerType === 'hybrid'" class="strategy-toggle-row">
+          <label class="strategy-toggle">
+            <input v-model="draft.mergePeers" type="checkbox" data-e2e="strategy-merge-peers" />
+            <span>{{ t('strategy.mergePeers') }}</span>
+          </label>
+        </div>
+
+        <div v-if="draft.chunkerType === 'hybrid'" class="strategy-toggle-row">
+          <label class="strategy-toggle">
+            <input
+              v-model="draft.repeatTableHeader"
+              type="checkbox"
+              data-e2e="strategy-repeat-table-header"
+            />
+            <span>{{ t('strategy.repeatTableHeader') }}</span>
+          </label>
+        </div>
+
+        <footer class="strategy-popover-actions">
+          <button class="strategy-btn strategy-btn--secondary" @click="onClose">
+            {{ t('strategy.cancel') }}
+          </button>
+          <button
+            class="strategy-btn strategy-btn--primary"
+            data-e2e="strategy-apply"
+            :disabled="rechunking"
+            @click="onApplyClick"
+          >
+            {{ rechunking ? t('strategy.rechunking') : t('strategy.apply') }}
+          </button>
+        </footer>
+      </div>
+
+      <!-- Confirm step (manual edits would be lost) -->
+      <div v-else-if="step === 'confirm'" class="strategy-popover-body" data-e2e="strategy-confirm">
+        <p class="strategy-popover-warning">⚠ {{ t('strategy.confirmWarning') }}</p>
+        <p class="strategy-popover-hint">{{ t('strategy.confirmHint') }}</p>
+        <footer class="strategy-popover-actions">
+          <button class="strategy-btn strategy-btn--secondary" @click="step = 'form'">
+            {{ t('strategy.confirmBack') }}
+          </button>
+          <button
+            class="strategy-btn strategy-btn--danger"
+            data-e2e="strategy-confirm-apply"
+            :disabled="rechunking"
+            @click="commitApply"
+          >
+            {{ rechunking ? t('strategy.rechunking') : t('strategy.confirmApply') }}
+          </button>
+        </footer>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * Strategy popover (#268) — inline rechunk-options form anchored to the
+ * Chunks panel header. Mirrors the domain `ChunkingOptions` (chunker
+ * type, max tokens, merge peers, repeat table header). Apply triggers
+ * `chunksStore.rechunk(docId, draft)`.
+ *
+ * Confirm step: when at least one chunk has been hand-edited
+ * (`updatedAt !== createdAt`, surfaced via `hasManualEdits`), the apply
+ * button routes through a warning screen first so the user does not
+ * silently lose their edits.
+ */
+import { reactive, ref, watch } from 'vue'
+import type { RechunkOptions } from '../../document/api'
+import { useI18n } from '../../../shared/i18n'
+
+const props = defineProps<{
+  open: boolean
+  hasManualEdits: boolean
+  rechunking: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  apply: [options: RechunkOptions]
+}>()
+
+const { t } = useI18n()
+
+type Step = 'form' | 'confirm'
+const step = ref<Step>('form')
+
+const DEFAULT_OPTIONS: Required<RechunkOptions> = {
+  chunkerType: 'hybrid',
+  maxTokens: 512,
+  mergePeers: true,
+  repeatTableHeader: true,
+}
+
+const draft = reactive<Required<RechunkOptions>>({ ...DEFAULT_OPTIONS })
+
+// Reset the form + step every time the popover is (re-)opened.
+watch(
+  () => props.open,
+  (now) => {
+    if (now) {
+      Object.assign(draft, DEFAULT_OPTIONS)
+      step.value = 'form'
+    }
+  },
+)
+
+function onClose(): void {
+  if (props.rechunking) return
+  emit('close')
+}
+
+function onApplyClick(): void {
+  // Gate behind a confirm step only when manual edits exist.
+  if (props.hasManualEdits) {
+    step.value = 'confirm'
+    return
+  }
+  commitApply()
+}
+
+function commitApply(): void {
+  emit('apply', sanitize(draft))
+}
+
+function sanitize(options: Required<RechunkOptions>): RechunkOptions {
+  // Hierarchical chunker ignores merge / table-header options on the
+  // backend; drop them client-side to keep the wire request honest.
+  if (options.chunkerType === 'hierarchical') {
+    return { chunkerType: options.chunkerType, maxTokens: options.maxTokens }
+  }
+  return { ...options }
+}
+</script>
+
+<style scoped>
+.strategy-popover-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.strategy-popover {
+  width: 380px;
+  max-width: 92vw;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.strategy-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.strategy-popover-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.strategy-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.strategy-close:hover {
+  color: var(--text);
+}
+
+.strategy-popover-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.strategy-popover-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.strategy-popover-warning {
+  margin: 0;
+  padding: 8px 10px;
+  background: rgba(234, 179, 8, 0.1);
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.strategy-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.strategy-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.strategy-select,
+.strategy-input {
+  padding: 6px 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+}
+
+.strategy-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.strategy-toggle-row {
+  display: flex;
+  align-items: center;
+}
+
+.strategy-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.strategy-popover-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  margin: 8px -14px -14px;
+  padding: 10px 14px;
+}
+
+.strategy-btn {
+  padding: 5px 14px;
+  font-size: 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.strategy-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.strategy-btn--secondary {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+}
+
+.strategy-btn--secondary:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.strategy-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.strategy-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.strategy-btn--danger {
+  background: #b91c1c;
+  border-color: #b91c1c;
+  color: white;
+}
+
+.strategy-btn--danger:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+</style>

--- a/frontend/src/features/document/api.ts
+++ b/frontend/src/features/document/api.ts
@@ -27,12 +27,26 @@ export function getPreviewUrl(id: string, page = 1, dpi = 150): string {
   return `/api/documents/${id}/preview?page=${page}&dpi=${dpi}`
 }
 
+/**
+ * Camel-case chunking options for the rechunk endpoint (#268). The
+ * backend `ChunkingOptionsRequest` accepts both snake_case and camelCase
+ * via `AliasChoices`; the rest of the API contract is camelCase, so the
+ * new Linked/Chunk view sticks to camelCase too.
+ */
+export interface RechunkOptions {
+  chunkerType?: 'hybrid' | 'hierarchical'
+  maxTokens?: number
+  mergePeers?: boolean
+  repeatTableHeader?: boolean
+}
+
 /** Rechunk the canonical chunkset. Backend runs synchronously and returns
  * the new chunks — there is no async job to poll. */
-export function rechunkDocument(id: string): Promise<DocChunk[]> {
+export function rechunkDocument(id: string, options?: RechunkOptions): Promise<DocChunk[]> {
+  const body = options ? { chunkingOptions: options } : {}
   return apiFetch<DocChunk[]>(`/api/documents/${id}/rechunk`, {
     method: 'POST',
-    body: JSON.stringify({}),
+    body: JSON.stringify(body),
   })
 }
 

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -423,12 +423,30 @@ const messages: Messages = {
     // Chunk view (#264) \u2014 chunks aligned to the page preview
     'chunk.showLabels': 'Afficher les libell\u00e9s',
     'chunk.strategy': 'Strat\u00e9gie',
-    'chunk.strategySoon': 'Strat\u00e9gie \u2014 param\u00e8tres de rechunk \u00e0 venir',
     'chunk.panel.title': 'Chunks',
     'chunk.panel.count': '{n} sur {total} en page {page}',
     'chunk.panel.emptyOnPage': 'Aucun chunk en page {page}.',
     'chunk.panel.edited': 'modifi\u00e9',
     'chunk.noAnalysis': "Aucune analyse \u2014 lancez d'abord un parse.",
+
+    // Strategy popover (#268) \u2014 inline rechunk options
+    'strategy.title': 'Strat\u00e9gie de chunking',
+    'strategy.close': 'Fermer',
+    'strategy.hint':
+      'Recalcule l\u2019ensemble des chunks \u00e0 partir de la derni\u00e8re analyse.',
+    'strategy.chunkerType': 'Type',
+    'strategy.maxTokens': 'Tokens max',
+    'strategy.maxTokensHint': 'Entre 64 et 8192.',
+    'strategy.mergePeers': 'Fusionner les pairs',
+    'strategy.repeatTableHeader': 'R\u00e9p\u00e9ter les en-t\u00eates de tableaux',
+    'strategy.cancel': 'Annuler',
+    'strategy.apply': 'Appliquer',
+    'strategy.rechunking': 'Re-chunkage\u2026',
+    'strategy.confirmWarning':
+      'Des chunks ont \u00e9t\u00e9 \u00e9dit\u00e9s manuellement. Re-chunker \u00e9crasera ces modifications.',
+    'strategy.confirmHint': 'Continuer ?',
+    'strategy.confirmBack': 'Retour',
+    'strategy.confirmApply': 'Re-chunker quand m\u00eame',
 
     // Doc tree rail (#217)
     'tree.empty': "Aucun n\u0153ud dans l'arbre.",
@@ -953,12 +971,30 @@ const messages: Messages = {
     // Chunk view (#264) — chunks aligned to the page preview
     'chunk.showLabels': 'Show labels',
     'chunk.strategy': 'Strategy',
-    'chunk.strategySoon': 'Strategy — rechunk options coming soon',
     'chunk.panel.title': 'Chunks',
     'chunk.panel.count': '{n} of {total} on page {page}',
     'chunk.panel.emptyOnPage': 'No chunks on page {page}.',
     'chunk.panel.edited': 'edited',
     'chunk.noAnalysis': 'No analysis yet — run a parse first.',
+
+    // Strategy popover (#268) — inline rechunk options
+    'strategy.title': 'Chunking strategy',
+    'strategy.close': 'Close',
+    'strategy.hint':
+      'Re-runs the chunker on the latest analysis and replaces the current chunkset.',
+    'strategy.chunkerType': 'Type',
+    'strategy.maxTokens': 'Max tokens',
+    'strategy.maxTokensHint': 'Between 64 and 8192.',
+    'strategy.mergePeers': 'Merge peers',
+    'strategy.repeatTableHeader': 'Repeat table headers',
+    'strategy.cancel': 'Cancel',
+    'strategy.apply': 'Apply',
+    'strategy.rechunking': 'Rechunking…',
+    'strategy.confirmWarning':
+      'Some chunks have been hand-edited. Rechunking will overwrite those edits.',
+    'strategy.confirmHint': 'Proceed anyway?',
+    'strategy.confirmBack': 'Back',
+    'strategy.confirmApply': 'Rechunk anyway',
 
     // Doc tree rail (#217)
     'tree.empty': 'No nodes in tree.',


### PR DESCRIPTION
## Summary

The `Strategy` button in the Chunk panel header was rendered inert in T3 (#264). It now opens a popover with the chunker options, applies them via the existing `POST /rechunk` endpoint, and refreshes the canonical chunkset in place — no Studio round-trip.

## What changed

**New component — `features/chunks/ui/StrategyPopover.vue`**

- Form fields mirror the domain `ChunkingOptions`: chunker type (`hybrid` / `hierarchical`), max tokens (64–8192), merge peers, repeat table header.
- The last two are only relevant for hybrid; they're hidden when hierarchical is selected and stripped from the wire request in `sanitize()` to keep the body honest.
- Two-step flow:
  - Apply runs straight through when no chunk has been hand-edited.
  - Routes through a **warning screen** otherwise so manual edits aren't silently overwritten. The "Rechunk anyway" button on the warning screen is styled as a danger action.
- Draft state resets every time the popover (re-)opens.
- Backdrop click + close button close the popover, except while a rechunk is in flight.

**Store — `features/chunks/store.ts`**

- New `rechunk(docId, options)` action wraps `rechunkDocument`, swaps the canonical chunks list with the response, and exposes a `rechunking` flag. Returns `true` on success so the caller can decide what to do (the popover dismisses on success).
- New `hasManualEdits` getter (`updatedAt !== createdAt`) feeds the confirm-step gating in the popover. Pure derived value, no side effects.

**API — `features/document/api.ts`**

- `rechunkDocument(id, options?)` now accepts the camel-case `RechunkOptions` object. The backend `ChunkingOptionsRequest` already accepts both snake_case and camelCase via `AliasChoices`; the new code sticks to camelCase like the rest of the API contract (Studio's existing snake_case path stays untouched).

**i18n**

- `strategy.*` namespace added (en + fr): title, hint, field labels, confirm warning, action labels.
- Obsolete `chunk.strategySoon` key removed (the button is no longer in the "coming soon" state).

**E2E**

- `doc-strategy-popover.feature` — opens the popover, changes max tokens, applies, asserts the popover closes and the chunks list still renders.

## Test plan

- [x] Frontend: `npm run lint && type-check && test:run` — **339 passed**
- [x] Frontend: prettier clean
- [x] Backend: untouched (route `/rechunk` shipped by #256)
- [ ] Manual: `Strategy` opens the popover; default values are `hybrid / 512 / true / true`
- [ ] Manual: select `hierarchical` → merge peers + repeat table header inputs hidden
- [ ] Manual: apply with no manual edits → popover closes, chunks refresh
- [ ] Manual: edit a chunk inline (T4), reopen Strategy, apply → confirm screen shown; click "Rechunk anyway" → rechunk runs
- [ ] Manual: backdrop click closes the popover except while rechunking is in flight

Closes #268
