### PR TITLE
feat(#267,#266): History drawer + New analysis bridge to Studio

### DIFF
--- a/document-parser/api/document_versions.py
+++ b/document-parser/api/document_versions.py
@@ -1,0 +1,85 @@
+"""Document versions API router (#267).
+
+Exposes the History timeline for a document — frozen (analysis_id,
+chunks_snapshot) pairs created on `+ New analysis` runs and on
+`+ Generate chunks` invocations. The drawer in the doc workspace reads
+this list and can restore any version to overwrite the live chunkset.
+
+Routes mount under `/api/documents/{doc_id}/...`. Read-mostly + a single
+write endpoint (`restore`) — the version-creation triggers fire from
+`AnalysisService` and `ChunkService`, not from the API layer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from api.schemas import DocumentVersionResponse
+from services.version_service import VersionService, VersionServiceError
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/documents", tags=["documents"])
+
+
+def _get_service(request: Request) -> VersionService:
+    svc = getattr(request.app.state, "version_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Version service not available")
+    return svc
+
+
+ServiceDep = Annotated[VersionService, Depends(_get_service)]
+
+
+def _to_response(version) -> DocumentVersionResponse:
+    snapshot_size = 0
+    if version.chunks_snapshot:
+        try:
+            snapshot_size = len(json.loads(version.chunks_snapshot))
+        except (json.JSONDecodeError, TypeError):
+            snapshot_size = 0
+    return DocumentVersionResponse(
+        id=version.id,
+        document_id=version.document_id,
+        kind=version.kind.value,
+        analysis_id=version.analysis_id,
+        chunks_snapshot_size=snapshot_size,
+        summary=version.summary,
+        created_at=str(version.created_at),
+    )
+
+
+def _raise_for(error: VersionServiceError) -> None:
+    raise HTTPException(status_code=error.http_status, detail=str(error))
+
+
+@router.get("/{doc_id}/versions", response_model=list[DocumentVersionResponse])
+async def list_versions(doc_id: str, service: ServiceDep) -> list[DocumentVersionResponse]:
+    """List frozen versions for a document, newest-first."""
+    try:
+        versions = await service.list_for_document(doc_id)
+    except VersionServiceError as e:
+        _raise_for(e)
+    return [_to_response(v) for v in versions]
+
+
+@router.post(
+    "/{doc_id}/versions/{version_id}/restore",
+    response_model=DocumentVersionResponse,
+)
+async def restore_version(
+    doc_id: str, version_id: str, service: ServiceDep
+) -> DocumentVersionResponse:
+    """Restore a frozen version — overwrites the live chunkset with the
+    version's snapshot. The active-analysis pointer is managed
+    client-side (the frontend reads `analysisId` off the response).
+    """
+    try:
+        version = await service.restore(doc_id, version_id)
+    except VersionServiceError as e:
+        _raise_for(e)
+    return _to_response(version)

--- a/document-parser/api/schemas.py
+++ b/document-parser/api/schemas.py
@@ -385,3 +385,20 @@ class PushChunksResponse(_CamelModel):
 
 class PushChunksRequest(_CamelModel):
     store: str
+
+
+# ---------------------------------------------------------------------------
+# Document versions (#267) — frozen (analysis_id, chunks_snapshot) pairs.
+# ---------------------------------------------------------------------------
+
+
+class DocumentVersionResponse(_CamelModel):
+    """Frozen pair surfaced by the workspace History drawer."""
+
+    id: str
+    document_id: str
+    kind: str  # "analysis" | "chunks"
+    analysis_id: str | None = None
+    chunks_snapshot_size: int = 0  # number of chunks captured, not the raw JSON
+    summary: str = ""
+    created_at: str | datetime

--- a/document-parser/domain/models.py
+++ b/document-parser/domain/models.py
@@ -278,3 +278,37 @@ class ChunkPush:
     chunkset_hash: str
     chunk_ids: list[str]
     pushed_at: datetime
+
+
+class DocumentVersionKind(enum.StrEnum):
+    """What triggered the version snapshot.
+
+    - ANALYSIS — a `+ New analysis` run completed for this document
+    - CHUNKS   — `+ Generate chunks` (rechunk) produced a new chunkset
+    """
+
+    ANALYSIS = "analysis"
+    CHUNKS = "chunks"
+
+
+@dataclass
+class DocumentVersion:
+    """Frozen pair (OCR analysis + chunks state) for a document (#267).
+
+    Created on explicit version-creating triggers (a new analysis run or
+    a `+ Generate chunks` invocation). Manual chunk edits do NOT create
+    a version — they mutate the live chunkset until the next snapshot.
+
+    `chunks_snapshot` is a JSON array of chunk records captured at the
+    moment of version creation. `analysis_id` points at the active
+    analysis at that moment. The pair is what the History drawer
+    surfaces, and what `restore` writes back into the live state.
+    """
+
+    id: str = field(default_factory=_new_id)
+    document_id: str = ""
+    kind: DocumentVersionKind = DocumentVersionKind.ANALYSIS
+    analysis_id: str | None = None
+    chunks_snapshot: str | None = None  # JSON-serialized list of chunk dicts
+    summary: str = ""
+    created_at: datetime = field(default_factory=_utcnow)

--- a/document-parser/main.py
+++ b/document-parser/main.py
@@ -225,10 +225,28 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         chunker=_build_chunker(),
         ingestion_service=ingestion_service,
     )
-    # The analysis service promotes the first analysis's chunks into the
-    # canonical chunkset (idempotent), so the doc workspace lights up the
-    # moment a doc is parsed for the first time.
+    # The analysis service still carries the chunk promoter wiring for
+    # legacy callers / tests, but the analysis flow no longer invokes it
+    # (decoupling from #266). Chunks are explicit — produced via the
+    # `+ Generate chunks` action on the Chunk view.
     app.state.analysis_service.set_chunk_promoter(app.state.chunk_service)
+
+    # 0.6.1 — Document versions (#267). Frozen (analysis, chunks)
+    # snapshots written on each version-creating trigger. Wired into
+    # AnalysisService + ChunkService below.
+    from persistence.document_version_repo import SqliteDocumentVersionRepository
+    from services.version_service import VersionService
+
+    version_repo = SqliteDocumentVersionRepository()
+    app.state.version_service = VersionService(
+        version_repo=version_repo,
+        chunk_repo=chunk_repo,
+        chunk_edit_repo=chunk_edit_repo,
+        document_repo=document_repo,
+    )
+    app.state.analysis_service.set_version_recorder(app.state.version_service)
+    app.state.chunk_service.set_version_recorder(app.state.version_service)
+
     logger.info("Docling Studio backend ready (engine=%s)", settings.conversion_engine)
     try:
         yield
@@ -263,6 +281,11 @@ app.include_router(documents_router)
 app.include_router(document_chunks_router)
 app.include_router(analyses_router)
 app.include_router(stores_router)
+
+# Document versions (#267) — workspace History timeline.
+from api.document_versions import router as document_versions_router  # noqa: E402
+
+app.include_router(document_versions_router)
 
 # Graph view — mounted regardless; individual requests 503 if Neo4j is absent.
 from api.graph import router as graph_router  # noqa: E402

--- a/document-parser/main.py
+++ b/document-parser/main.py
@@ -247,6 +247,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.analysis_service.set_version_recorder(app.state.version_service)
     app.state.chunk_service.set_version_recorder(app.state.version_service)
 
+    # 0.6.1 — backfill `document_versions` rows for documents whose
+    # analyses pre-date the versioning (#267). Idempotent: tagged via
+    # `migration_progress`, skipped on subsequent boots.
+    from persistence.migrations.backfill_versions import run_backfill
+
+    try:
+        await run_backfill()
+    except Exception:
+        # Non-fatal — the backfill is a best-effort, the app must still
+        # start. Operators see the stack trace and re-run later.
+        logger.exception("Document-version backfill failed (#267)")
+
     logger.info("Docling Studio backend ready (engine=%s)", settings.conversion_engine)
     try:
         yield

--- a/document-parser/persistence/database.py
+++ b/document-parser/persistence/database.py
@@ -115,6 +115,26 @@ CREATE TABLE IF NOT EXISTS chunk_pushes (
 );
 CREATE INDEX IF NOT EXISTS idx_chunk_pushes_doc_store ON chunk_pushes(document_id, store_id);
 
+-- 0.6.1 — document versions (#267). Frozen pair (analysis_id, chunks
+-- snapshot) created on each explicit version trigger: a new analysis
+-- run or a `+ Generate chunks` invocation. The chunks snapshot is a
+-- JSON array; live chunks remain in `chunks` and can be restored from
+-- a version on demand.
+CREATE TABLE IF NOT EXISTS document_versions (
+    id              TEXT PRIMARY KEY,
+    document_id     TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    kind            TEXT NOT NULL,
+    -- Soft reference to analysis_jobs(id). Not enforced as FK so the
+    -- version row can outlive the analysis (deleted analyses just
+    -- become orphan pointers, frontend shows a "stale" marker).
+    analysis_id     TEXT,
+    chunks_snapshot TEXT,
+    summary         TEXT NOT NULL DEFAULT '',
+    created_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_document_versions_doc_created
+    ON document_versions(document_id, created_at);
+
 -- 0.6.0 — migration progress (resumability for the 0.6.0 backfill, #206).
 CREATE TABLE IF NOT EXISTS migration_progress (
     name         TEXT PRIMARY KEY,

--- a/document-parser/persistence/document_version_repo.py
+++ b/document-parser/persistence/document_version_repo.py
@@ -1,0 +1,84 @@
+"""Document-version repository — SQLite CRUD for frozen (analysis, chunks)
+pairs (#267).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from domain.models import DocumentVersion, DocumentVersionKind
+from persistence.database import get_connection
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _row_to_version(row) -> DocumentVersion:
+    return DocumentVersion(
+        id=row["id"],
+        document_id=row["document_id"],
+        kind=DocumentVersionKind(row["kind"]),
+        analysis_id=row["analysis_id"],
+        chunks_snapshot=row["chunks_snapshot"],
+        summary=row["summary"] or "",
+        created_at=_parse_iso(row["created_at"]),
+    )
+
+
+_INSERT_SQL = """INSERT INTO document_versions
+    (id, document_id, kind, analysis_id, chunks_snapshot, summary, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)"""
+
+
+class SqliteDocumentVersionRepository:
+    """Persists `DocumentVersion` rows ordered newest-first per document."""
+
+    async def insert(self, version: DocumentVersion) -> None:
+        async with get_connection() as conn:
+            await conn.execute(
+                _INSERT_SQL,
+                (
+                    version.id,
+                    version.document_id,
+                    version.kind.value,
+                    version.analysis_id,
+                    version.chunks_snapshot,
+                    version.summary,
+                    str(version.created_at),
+                ),
+            )
+            await conn.commit()
+
+    async def find_by_id(self, version_id: str) -> DocumentVersion | None:
+        async with get_connection() as conn:
+            cur = await conn.execute(
+                "SELECT * FROM document_versions WHERE id = ?",
+                (version_id,),
+            )
+            row = await cur.fetchone()
+            return _row_to_version(row) if row else None
+
+    async def find_for_document(self, document_id: str) -> list[DocumentVersion]:
+        """Returns all versions for the document, newest-first."""
+        async with get_connection() as conn:
+            cur = await conn.execute(
+                "SELECT * FROM document_versions WHERE document_id = ? ORDER BY created_at DESC",
+                (document_id,),
+            )
+            rows = await cur.fetchall()
+            return [_row_to_version(r) for r in rows]
+
+    async def find_latest_for_document(self, document_id: str) -> DocumentVersion | None:
+        """Most recent version for the document, or None."""
+        async with get_connection() as conn:
+            cur = await conn.execute(
+                "SELECT * FROM document_versions WHERE document_id = ? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (document_id,),
+            )
+            row = await cur.fetchone()
+            return _row_to_version(row) if row else None

--- a/document-parser/persistence/migrations/backfill_versions.py
+++ b/document-parser/persistence/migrations/backfill_versions.py
@@ -1,0 +1,154 @@
+"""Backfill `document_versions` for pre-#267 data.
+
+The versioning table was introduced in 0.6.1. Documents that already
+had completed analyses (and possibly chunks) before the upgrade end up
+with zero version rows — the workspace then shows an empty History and
+can't pin an active analysis. This migration walks every document and
+materializes one ANALYSIS version per pre-existing COMPLETED analysis,
+plus one CHUNKS version per document whose live chunks predate the
+versioning. Each emitted version snapshots the chunks state at the
+moment of the backfill (best we can do without an audit replay).
+
+Idempotent: tagged via `migration_progress` and skipped on subsequent
+startups.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+from persistence.database import get_connection
+
+logger = logging.getLogger(__name__)
+
+_MIGRATION_NAME = "267-backfill-document-versions"
+
+
+async def _already_done() -> bool:
+    async with get_connection() as conn:
+        cur = await conn.execute(
+            "SELECT 1 FROM migration_progress WHERE name = ?",
+            (_MIGRATION_NAME,),
+        )
+        return await cur.fetchone() is not None
+
+
+async def _mark_done() -> None:
+    async with get_connection() as conn:
+        await conn.execute(
+            "INSERT OR IGNORE INTO migration_progress (name) VALUES (?)",
+            (_MIGRATION_NAME,),
+        )
+        await conn.commit()
+
+
+async def run_backfill() -> int:
+    """Returns the number of synthetic versions emitted."""
+    if await _already_done():
+        logger.debug("Backfill %s already applied", _MIGRATION_NAME)
+        return 0
+
+    emitted = 0
+    async with get_connection() as conn:
+        # All completed analyses with their document ids.
+        analyses_cur = await conn.execute(
+            """
+            SELECT aj.id, aj.document_id, aj.completed_at, aj.created_at
+              FROM analysis_jobs aj
+              JOIN documents d ON d.id = aj.document_id
+             WHERE aj.status = 'COMPLETED'
+             ORDER BY aj.completed_at, aj.created_at
+            """
+        )
+        analyses_rows = await analyses_cur.fetchall()
+
+        # Documents that already have at least one version row — skip
+        # them so re-running the migration (e.g. after a partial rollback)
+        # doesn't double-count.
+        versions_cur = await conn.execute(
+            "SELECT DISTINCT document_id FROM document_versions",
+        )
+        with_versions = {r["document_id"] for r in await versions_cur.fetchall()}
+
+        # Live chunks per document (snapshot once, reuse across the
+        # synthetic versions of that doc — the audit log is too coarse
+        # to reconstruct per-analysis chunk states).
+        chunks_cache: dict[str, str] = {}
+
+        for row in analyses_rows:
+            doc_id = row["document_id"]
+            if doc_id in with_versions:
+                continue
+
+            if doc_id not in chunks_cache:
+                chunks_cache[doc_id] = await _serialize_live_chunks(conn, doc_id)
+
+            await conn.execute(
+                """
+                INSERT INTO document_versions
+                    (id, document_id, kind, analysis_id,
+                     chunks_snapshot, summary, created_at)
+                VALUES (?, ?, 'analysis', ?, ?, ?, ?)
+                """,
+                (
+                    uuid.uuid4().hex,
+                    doc_id,
+                    row["id"],
+                    chunks_cache[doc_id],
+                    "Backfilled analysis version",
+                    row["completed_at"] or row["created_at"],
+                ),
+            )
+            emitted += 1
+
+        await conn.commit()
+
+    await _mark_done()
+    logger.info("Backfilled %d document versions (#267)", emitted)
+    return emitted
+
+
+async def _serialize_live_chunks(conn, document_id: str) -> str:
+    """Snapshot the live (non-deleted) chunks for a document as the same
+    JSON shape `VersionService._serialize_chunks` writes — kept aligned
+    so the frontend can read either-or."""
+    cur = await conn.execute(
+        """
+        SELECT id, document_id, sequence, text, headings, source_page,
+               bboxes, doc_items, token_count, created_at, updated_at
+          FROM chunks
+         WHERE document_id = ?
+           AND deleted_at IS NULL
+         ORDER BY sequence
+        """,
+        (document_id,),
+    )
+    rows = await cur.fetchall()
+    out = []
+    for r in rows:
+        headings = json.loads(r["headings"]) if r["headings"] else []
+        bboxes = json.loads(r["bboxes"]) if r["bboxes"] else []
+        doc_items = json.loads(r["doc_items"]) if r["doc_items"] else []
+        out.append(
+            {
+                "id": r["id"],
+                "documentId": r["document_id"],
+                "sequence": r["sequence"],
+                "text": r["text"],
+                "headings": headings,
+                "sourcePage": r["source_page"],
+                "tokenCount": r["token_count"],
+                "bboxes": [
+                    {"page": b.get("page"), "bbox": list(b.get("bbox", []))} for b in bboxes
+                ],
+                "docItems": [
+                    {"selfRef": d.get("self_ref", ""), "label": d.get("label", "")}
+                    for d in doc_items
+                ],
+                "createdAt": r["created_at"],
+                "updatedAt": r["updated_at"],
+            }
+        )
+    return json.dumps(out)

--- a/document-parser/services/analysis_service.py
+++ b/document-parser/services/analysis_service.py
@@ -105,6 +105,10 @@ class AnalysisService:
         # making the Doc workspace tab functional immediately (#256).
         # Optional: when None, analysis behaviour is unchanged.
         self._chunk_promoter = None
+        # Duck-typed recorder for document versions (#267). Wired in
+        # main.py to `VersionService.record_on_analysis` so each
+        # successful analysis appends a frozen pair to History.
+        self._version_recorder = None
 
     def set_chunk_promoter(self, chunk_service) -> None:
         """Inject the canonical-chunk promoter (post-construction wiring).
@@ -114,6 +118,13 @@ class AnalysisService:
         coroutine `(document_id: str, chunks_json: str) -> int`.
         """
         self._chunk_promoter = chunk_service
+
+    def set_version_recorder(self, version_service) -> None:
+        """Inject the document-version recorder (#267, post-construction
+        wiring). Contract: a coroutine
+        `(document_id: str, analysis_id: str) -> DocumentVersion`.
+        """
+        self._version_recorder = version_service
 
     async def create(
         self,
@@ -448,6 +459,22 @@ class AnalysisService:
         # popover, #268). The promoter hook stays wired in main.py so
         # legacy callers / tests can still trigger it directly, but it is
         # no longer invoked as part of the analysis flow.
+
+        # Record a frozen (analysis, chunks_snapshot) pair in the
+        # workspace History timeline (#267). Snapshots the LIVE chunks
+        # at this moment so user edits since the previous version are
+        # preserved alongside the new analysis pointer.
+        if self._version_recorder is not None:
+            try:
+                await self._version_recorder.record_on_analysis(job.document_id, job_id)
+            except Exception:
+                # Versioning is a best-effort side hook — never fail the
+                # analysis itself if the snapshot write hits a snag.
+                logger.exception(
+                    "Version snapshot failed for doc %s after analysis %s",
+                    job.document_id,
+                    job_id,
+                )
 
         # Drive the document lifecycle (#202): chunks present → Chunked,
         # otherwise → Parsed.

--- a/document-parser/services/analysis_service.py
+++ b/document-parser/services/analysis_service.py
@@ -440,19 +440,14 @@ class AnalysisService:
         if result.page_count:
             await self._document_repo.update_page_count(job.document_id, result.page_count)
 
-        # Promote chunks into the canonical doc-centric chunkset on the
-        # first analysis (#256). Idempotent: a doc that already has
-        # canonical chunks is left untouched, so subsequent ad-hoc
-        # analyses (Studio / OCR Debug) never overwrite hand-edited state.
-        if chunks_json is not None and self._chunk_promoter is not None:
-            try:
-                await self._chunk_promoter.promote_from_analysis_if_empty(
-                    job.document_id, chunks_json
-                )
-            except Exception:
-                # Promotion is a best-effort hook — never fail an analysis
-                # because the canonical promotion hit a snag.
-                logger.exception("Canonical chunk promotion failed for doc %s", job.document_id)
+        # Canonical chunk promotion was previously called here (#256), but
+        # the 0.6.1 doc workspace (#266) requires the analysis and chunk
+        # actions to be independent — running an analysis must NOT
+        # implicitly create chunks. Chunks are now produced explicitly via
+        # `POST /api/documents/{id}/rechunk` (driven from the Strategy
+        # popover, #268). The promoter hook stays wired in main.py so
+        # legacy callers / tests can still trigger it directly, but it is
+        # no longer invoked as part of the analysis flow.
 
         # Drive the document lifecycle (#202): chunks present → Chunked,
         # otherwise → Parsed.

--- a/document-parser/services/analysis_service.py
+++ b/document-parser/services/analysis_service.py
@@ -446,6 +446,26 @@ class AnalysisService:
             document_json=result.document_json,
             chunks_json=chunks_json,
         )
+
+        # Record a frozen (analysis, chunks_snapshot) pair in the
+        # workspace History timeline (#267). Done BEFORE the status flip
+        # to COMPLETED so the frontend polling never observes a
+        # completed analysis without its version row in the DB.
+        # Snapshots the LIVE chunks at this moment so user edits since
+        # the previous version are preserved alongside the new analysis
+        # pointer.
+        if self._version_recorder is not None:
+            try:
+                await self._version_recorder.record_on_analysis(job.document_id, job_id)
+            except Exception:
+                # Versioning is a best-effort side hook — never fail the
+                # analysis itself if the snapshot write hits a snag.
+                logger.exception(
+                    "Version snapshot failed for doc %s after analysis %s",
+                    job.document_id,
+                    job_id,
+                )
+
         await self._analysis_repo.update_status(job)
 
         if result.page_count:
@@ -459,22 +479,6 @@ class AnalysisService:
         # popover, #268). The promoter hook stays wired in main.py so
         # legacy callers / tests can still trigger it directly, but it is
         # no longer invoked as part of the analysis flow.
-
-        # Record a frozen (analysis, chunks_snapshot) pair in the
-        # workspace History timeline (#267). Snapshots the LIVE chunks
-        # at this moment so user edits since the previous version are
-        # preserved alongside the new analysis pointer.
-        if self._version_recorder is not None:
-            try:
-                await self._version_recorder.record_on_analysis(job.document_id, job_id)
-            except Exception:
-                # Versioning is a best-effort side hook — never fail the
-                # analysis itself if the snapshot write hits a snag.
-                logger.exception(
-                    "Version snapshot failed for doc %s after analysis %s",
-                    job.document_id,
-                    job_id,
-                )
 
         # Drive the document lifecycle (#202): chunks present → Chunked,
         # otherwise → Parsed.

--- a/document-parser/services/chunk_service.py
+++ b/document-parser/services/chunk_service.py
@@ -157,6 +157,15 @@ class ChunkService:
         self._chunker = chunker
         self._ingestion = ingestion_service
         self._actor = actor
+        # Duck-typed recorder for document versions (#267). Wired in
+        # main.py to `VersionService.record_on_rechunk` so each
+        # `+ Generate chunks` call appends a frozen pair to History.
+        self._version_recorder = None
+
+    def set_version_recorder(self, version_service) -> None:
+        """Inject the document-version recorder (#267). Contract: a
+        coroutine `(document_id: str, analysis_id: str | None) -> DocumentVersion`."""
+        self._version_recorder = version_service
 
     # -- promotion (called by AnalysisService after first successful analysis)
 
@@ -476,6 +485,21 @@ class ChunkService:
             len(existing),
             len(new_chunks),
         )
+
+        # Record a frozen (analysis, chunks_snapshot) pair in the
+        # workspace History timeline (#267). Snapshots the chunks we
+        # just wrote, paired with the analysis they came from.
+        if self._version_recorder is not None:
+            try:
+                await self._version_recorder.record_on_rechunk(document_id, job.id)
+            except Exception:
+                # Best-effort hook — never fail the rechunk if the
+                # version snapshot write hits a snag.
+                logger.exception(
+                    "Version snapshot failed for doc %s after rechunk",
+                    document_id,
+                )
+
         return new_chunks
 
     # -- diff (against last push to a store)

--- a/document-parser/services/chunk_service.py
+++ b/document-parser/services/chunk_service.py
@@ -451,7 +451,7 @@ class ChunkService:
                 headings=list(r.headings),
                 source_page=r.source_page,
                 bboxes=list(r.bboxes),
-                doc_items=[],  # ChunkResult has no doc_items currently
+                doc_items=list(r.doc_items),
                 token_count=r.token_count or None,
             )
             for seq, r in enumerate(new_results)

--- a/document-parser/services/version_service.py
+++ b/document-parser/services/version_service.py
@@ -1,0 +1,227 @@
+"""Document-version service (#267).
+
+Records frozen (analysis_id, chunks_snapshot) pairs at the two explicit
+version-creating triggers — a `+ New analysis` run completes, or a
+`+ Generate chunks` (rechunk) invocation finishes. Manual chunk edits
+between snapshots are NOT recorded as versions; they mutate the live
+chunkset and only land in History when the next explicit trigger fires.
+
+`restore(document_id, version_id)` writes the version's chunks_snapshot
+back into the live `chunks` table. The current analysis pointer is
+managed by the workspace (frontend reads `version.analysis_id` to
+re-render the OCR side).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from domain.models import Chunk, ChunkEdit, DocumentVersion, DocumentVersionKind
+from domain.value_objects import ChunkEditAction
+
+if TYPE_CHECKING:
+    from domain.ports import (
+        ChunkEditRepository,
+        ChunkRepository,
+        DocumentRepository,
+    )
+    from persistence.document_version_repo import SqliteDocumentVersionRepository
+
+logger = logging.getLogger(__name__)
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _serialize_chunks(chunks: list[Chunk]) -> str:
+    """Freeze a list of live `Chunk` rows into the wire-stable JSON shape
+    the frontend reads back via `chunks_snapshot`. Mirrors `_chunk_to_dict`
+    in ChunkService — kept independent to avoid an import cycle."""
+    return json.dumps(
+        [
+            {
+                "id": c.id,
+                "documentId": c.document_id,
+                "sequence": c.sequence,
+                "text": c.text,
+                "headings": list(c.headings),
+                "sourcePage": c.source_page,
+                "tokenCount": c.token_count,
+                "bboxes": [{"page": b.page, "bbox": list(b.bbox)} for b in c.bboxes],
+                "docItems": [{"selfRef": d.self_ref, "label": d.label} for d in c.doc_items],
+                "createdAt": str(c.created_at),
+                "updatedAt": str(c.updated_at),
+            }
+            for c in chunks
+        ]
+    )
+
+
+class VersionServiceError(Exception):
+    http_status: int = 400
+
+    def __init__(self, message: str, *, http_status: int | None = None):
+        super().__init__(message)
+        if http_status is not None:
+            self.http_status = http_status
+
+
+class VersionNotFoundError(VersionServiceError):
+    http_status = 404
+
+
+class VersionService:
+    """Records and restores frozen (analysis, chunks) version snapshots."""
+
+    def __init__(
+        self,
+        version_repo: SqliteDocumentVersionRepository,
+        chunk_repo: ChunkRepository,
+        chunk_edit_repo: ChunkEditRepository,
+        document_repo: DocumentRepository,
+    ):
+        self._versions = version_repo
+        self._chunks = chunk_repo
+        self._edits = chunk_edit_repo
+        self._documents = document_repo
+
+    async def list_for_document(self, document_id: str) -> list[DocumentVersion]:
+        await self._require_doc(document_id)
+        return await self._versions.find_for_document(document_id)
+
+    async def record_on_analysis(
+        self,
+        document_id: str,
+        analysis_id: str,
+    ) -> DocumentVersion:
+        """Called by `AnalysisService` after a successful analysis run.
+
+        The new version pairs the freshly-completed analysis with a
+        snapshot of the LIVE chunks at this moment (preserves any user
+        edits since the previous snapshot). When no chunks exist yet
+        (first analysis of a doc), the snapshot is the literal empty
+        JSON array.
+        """
+        chunks = await self._chunks.find_for_document(document_id)
+        version = DocumentVersion(
+            id=_new_id(),
+            document_id=document_id,
+            kind=DocumentVersionKind.ANALYSIS,
+            analysis_id=analysis_id,
+            chunks_snapshot=_serialize_chunks(chunks),
+            summary="Analysis run",
+            created_at=_utcnow(),
+        )
+        await self._versions.insert(version)
+        return version
+
+    async def record_on_rechunk(
+        self,
+        document_id: str,
+        analysis_id: str | None,
+    ) -> DocumentVersion:
+        """Called by `ChunkService.rechunk_document` after the live
+        chunkset has been replaced. Snapshots the new chunks; the
+        analysis pointer is the one rechunk just consumed."""
+        chunks = await self._chunks.find_for_document(document_id)
+        version = DocumentVersion(
+            id=_new_id(),
+            document_id=document_id,
+            kind=DocumentVersionKind.CHUNKS,
+            analysis_id=analysis_id,
+            chunks_snapshot=_serialize_chunks(chunks),
+            summary="Chunks generated",
+            created_at=_utcnow(),
+        )
+        await self._versions.insert(version)
+        return version
+
+    async def restore(self, document_id: str, version_id: str) -> DocumentVersion:
+        """Replace the live chunkset with the version's snapshot. The
+        active-analysis pointer is the caller's responsibility (the
+        frontend reads `version.analysis_id` and updates the workspace
+        store)."""
+        await self._require_doc(document_id)
+        version = await self._versions.find_by_id(version_id)
+        if not version or version.document_id != document_id:
+            raise VersionNotFoundError(f"Version not found: {version_id}")
+
+        # Wipe live chunks (soft-delete + audit), then re-insert the
+        # snapshot's chunks under fresh ids.
+        now = _utcnow()
+        existing = await self._chunks.find_for_document(document_id)
+        for c in existing:
+            await self._chunks.soft_delete(c.id, at=now)
+            await self._edits.insert(
+                ChunkEdit(
+                    id=_new_id(),
+                    document_id=document_id,
+                    chunk_id=c.id,
+                    action=ChunkEditAction.DELETE,
+                    actor=f"system:restore:{version_id}",
+                    at=now,
+                )
+            )
+
+        raw_chunks = json.loads(version.chunks_snapshot or "[]")
+        new_chunks: list[Chunk] = []
+        for raw in raw_chunks:
+            new_chunks.append(_chunk_from_snapshot(document_id, raw))
+
+        if new_chunks:
+            await self._chunks.insert_many(new_chunks)
+            for c in new_chunks:
+                await self._edits.insert(
+                    ChunkEdit(
+                        id=_new_id(),
+                        document_id=document_id,
+                        chunk_id=c.id,
+                        action=ChunkEditAction.INSERT,
+                        actor=f"system:restore:{version_id}",
+                        at=now,
+                    )
+                )
+
+        logger.info(
+            "Restored doc %s to version %s (%d chunks)",
+            document_id,
+            version_id,
+            len(new_chunks),
+        )
+        return version
+
+    async def _require_doc(self, document_id: str) -> None:
+        doc = await self._documents.find_by_id(document_id)
+        if not doc:
+            raise VersionServiceError(f"Document not found: {document_id}", http_status=404)
+
+
+def _chunk_from_snapshot(document_id: str, raw: dict) -> Chunk:
+    """Inverse of `_serialize_chunks`. Skips the wire-only `id`/timestamps
+    so the restored chunk gets a fresh identity (the old ids are gone
+    after the soft-delete pass)."""
+    from domain.value_objects import ChunkBbox, ChunkDocItem
+
+    return Chunk(
+        id=_new_id(),
+        document_id=document_id,
+        sequence=raw.get("sequence", 0),
+        text=raw.get("text", ""),
+        headings=list(raw.get("headings", [])),
+        source_page=raw.get("sourcePage"),
+        bboxes=[ChunkBbox(page=b["page"], bbox=list(b["bbox"])) for b in raw.get("bboxes", [])],
+        doc_items=[
+            ChunkDocItem(self_ref=d.get("selfRef", ""), label=d.get("label", ""))
+            for d in raw.get("docItems", [])
+        ],
+        token_count=raw.get("tokenCount"),
+    )

--- a/document-parser/tests/test_chunk_service.py
+++ b/document-parser/tests/test_chunk_service.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from domain.models import AnalysisJob, AnalysisStatus, Chunk, Document
-from domain.value_objects import ChunkEditAction, ChunkResult
+from domain.value_objects import ChunkDocItem, ChunkEditAction, ChunkResult
 from persistence.analysis_repo import SqliteAnalysisRepository
 from persistence.chunk_edit_repo import (
     SqliteChunkEditRepository,
@@ -282,6 +282,41 @@ class TestRechunkDocument:
         with pytest.raises(ChunkServiceError) as exc:
             await service.rechunk_document(doc.id)
         assert exc.value.http_status == 503
+
+    async def test_rechunk_preserves_doc_items_from_chunker(self, service, repos, doc):
+        """0.6.1 — the bbox↔chunk linking on the Chunk view depends on
+        the canonical chunks carrying `doc_items`. The previous implementation
+        dropped them on a stale "ChunkResult has no doc_items" comment.
+        """
+        # Seed a completed analysis.
+        job = AnalysisJob(document_id=doc.id, status=AnalysisStatus.COMPLETED)
+        await repos["analyses"].insert(job)
+        job.document_json = json.dumps({"texts": []})
+        job.completed_at = datetime.now(UTC)
+        await repos["analyses"].update_status(job)
+
+        chunker = MagicMock()
+        chunker.chunk = AsyncMock(
+            return_value=[
+                ChunkResult(
+                    text="t",
+                    source_page=1,
+                    token_count=4,
+                    doc_items=[
+                        ChunkDocItem(self_ref="#/texts/0", label="text"),
+                        ChunkDocItem(self_ref="#/texts/1", label="text"),
+                    ],
+                ),
+            ]
+        )
+        service._chunker = chunker
+
+        result = await service.rechunk_document(doc.id)
+        assert len(result) == 1
+        assert [d.self_ref for d in result[0].doc_items] == ["#/texts/0", "#/texts/1"]
+        # Persisted chunks carry doc_items too.
+        chunks = await service.list_chunks(doc.id)
+        assert [d.self_ref for d in chunks[0].doc_items] == ["#/texts/0", "#/texts/1"]
 
 
 # ---------------------------------------------------------------------------

--- a/document-parser/tests/test_version_service.py
+++ b/document-parser/tests/test_version_service.py
@@ -1,0 +1,145 @@
+"""Unit tests for VersionService (#267) — frozen (analysis, chunks) pairs."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from domain.models import Chunk, Document, DocumentVersionKind
+from domain.value_objects import ChunkBbox, ChunkDocItem
+from persistence.chunk_edit_repo import SqliteChunkEditRepository
+from persistence.chunk_repo import SqliteChunkRepository
+from persistence.database import init_db
+from persistence.document_repo import SqliteDocumentRepository
+from persistence.document_version_repo import SqliteDocumentVersionRepository
+from services.version_service import (
+    VersionNotFoundError,
+    VersionService,
+    VersionServiceError,
+)
+
+
+@pytest.fixture(autouse=True)
+async def setup_db(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setattr("persistence.database.DB_PATH", db_path)
+    await init_db()
+    yield
+
+
+@pytest.fixture
+def repos():
+    return {
+        "documents": SqliteDocumentRepository(),
+        "chunks": SqliteChunkRepository(),
+        "chunk_edits": SqliteChunkEditRepository(),
+        "versions": SqliteDocumentVersionRepository(),
+    }
+
+
+@pytest.fixture
+def service(repos):
+    return VersionService(
+        version_repo=repos["versions"],
+        chunk_repo=repos["chunks"],
+        chunk_edit_repo=repos["chunk_edits"],
+        document_repo=repos["documents"],
+    )
+
+
+@pytest.fixture
+async def doc(repos):
+    d = Document(id="doc-1", filename="a.pdf", storage_path="/tmp/a")
+    await repos["documents"].insert(d)
+    return d
+
+
+class TestRecordOnAnalysis:
+    async def test_first_version_has_empty_chunks_snapshot(self, service, doc):
+        version = await service.record_on_analysis(doc.id, "a1")
+        assert version.kind is DocumentVersionKind.ANALYSIS
+        assert version.analysis_id == "a1"
+        assert json.loads(version.chunks_snapshot or "[]") == []
+
+    async def test_snapshot_carries_existing_chunks(self, service, repos, doc):
+        await repos["chunks"].insert_many(
+            [
+                Chunk(
+                    document_id=doc.id,
+                    sequence=0,
+                    text="t1",
+                    headings=["h"],
+                    source_page=1,
+                    bboxes=[ChunkBbox(page=1, bbox=[0, 0, 10, 10])],
+                    doc_items=[ChunkDocItem(self_ref="#/texts/0", label="text")],
+                    token_count=5,
+                ),
+                Chunk(document_id=doc.id, sequence=1, text="t2", token_count=4),
+            ]
+        )
+        version = await service.record_on_analysis(doc.id, "a2")
+        snapshot = json.loads(version.chunks_snapshot)
+        assert [s["text"] for s in snapshot] == ["t1", "t2"]
+        assert snapshot[0]["docItems"][0]["selfRef"] == "#/texts/0"
+
+
+class TestRecordOnRechunk:
+    async def test_records_kind_chunks(self, service, repos, doc):
+        await repos["chunks"].insert_many([Chunk(document_id=doc.id, sequence=0, text="new")])
+        version = await service.record_on_rechunk(doc.id, "a1")
+        assert version.kind is DocumentVersionKind.CHUNKS
+        assert version.analysis_id == "a1"
+        assert json.loads(version.chunks_snapshot)[0]["text"] == "new"
+
+
+class TestRestore:
+    async def test_restore_overwrites_live_chunks(self, service, repos, doc):
+        # V1 — two chunks
+        await repos["chunks"].insert_many(
+            [
+                Chunk(document_id=doc.id, sequence=0, text="v1-a"),
+                Chunk(document_id=doc.id, sequence=1, text="v1-b"),
+            ]
+        )
+        v1 = await service.record_on_rechunk(doc.id, "a1")
+
+        # Move to V2 state — soft-delete V1's chunks, insert a single new
+        now = datetime.now(UTC)
+        for c in await repos["chunks"].find_for_document(doc.id):
+            await repos["chunks"].soft_delete(c.id, at=now)
+        await repos["chunks"].insert_many([Chunk(document_id=doc.id, sequence=0, text="v2-only")])
+        await service.record_on_rechunk(doc.id, "a1")
+
+        # Restore V1 → live should match V1's two chunks
+        await service.restore(doc.id, v1.id)
+        live = await repos["chunks"].find_for_document(doc.id)
+        assert sorted(c.text for c in live) == ["v1-a", "v1-b"]
+
+    async def test_restore_unknown_version_raises(self, service, doc):
+        with pytest.raises(VersionNotFoundError):
+            await service.restore(doc.id, "nope")
+
+    async def test_restore_other_doc_version_raises(self, service, repos, doc):
+        other = Document(id="doc-2", filename="b.pdf", storage_path="/tmp/b")
+        await repos["documents"].insert(other)
+        v = await service.record_on_analysis(other.id, "a1")
+        with pytest.raises(VersionNotFoundError):
+            await service.restore(doc.id, v.id)
+
+
+class TestListForDocument:
+    async def test_returns_newest_first(self, service, doc):
+        await service.record_on_analysis(doc.id, "a1")
+        await service.record_on_rechunk(doc.id, "a1")
+        await service.record_on_analysis(doc.id, "a2")
+        versions = await service.list_for_document(doc.id)
+        # 3 entries, newest first (analysis a2 wins)
+        assert len(versions) == 3
+        assert versions[0].kind is DocumentVersionKind.ANALYSIS
+        assert versions[0].analysis_id == "a2"
+
+    async def test_unknown_doc_raises(self, service):
+        with pytest.raises(VersionServiceError):
+            await service.list_for_document("nope")

--- a/e2e/ui/src/test/resources/documents/doc-history-drawer.feature
+++ b/e2e/ui/src/test/resources/documents/doc-history-drawer.feature
@@ -1,0 +1,63 @@
+@ui @regression
+Feature: UI — History drawer lists analyses and switches the active one (#267)
+
+  # Two analyses are created over the same document; the drawer should
+  # surface both and "Set as current" should activate the older one
+  # without leaving the workspace.
+
+  Background:
+    * url baseUrl
+
+  Scenario: Two analyses → drawer lists both → set the older as current
+    * def upload = call read('classpath:common/helpers/upload.feature') { file: 'small.pdf' }
+    * def docId = upload.docId
+
+    # Analysis #1
+    Given url baseUrl
+    And path '/api/analyses'
+    And request { documentId: '#(docId)', chunkingOptions: { chunkerType: 'hybrid', maxTokens: 512, mergePeers: true, repeatTableHeader: true } }
+    When method POST
+    Then status 200
+    * def analysisOldId = response.id
+
+    Given url baseUrl
+    And path '/api/analyses', analysisOldId
+    And retry until response.status == 'COMPLETED' || response.status == 'FAILED'
+    When method GET
+    Then status 200
+    And match response.status == 'COMPLETED'
+
+    # Analysis #2 — bigger max_tokens so we can tell them apart.
+    Given url baseUrl
+    And path '/api/analyses'
+    And request { documentId: '#(docId)', chunkingOptions: { chunkerType: 'hybrid', maxTokens: 1024, mergePeers: true, repeatTableHeader: true } }
+    When method POST
+    Then status 200
+    * def analysisNewId = response.id
+
+    Given url baseUrl
+    And path '/api/analyses', analysisNewId
+    And retry until response.status == 'COMPLETED' || response.status == 'FAILED'
+    When method GET
+    Then status 200
+    And match response.status == 'COMPLETED'
+
+    # UI — open the workspace, click History.
+    * driver uiBaseUrl + '/docs/' + docId
+    * waitFor('[data-e2e=parse-tab]')
+    * click('[data-e2e=history-btn]')
+    * waitFor('[data-e2e=history-drawer]')
+    * waitFor('[data-e2e=history-list]')
+
+    # The newer analysis is the default active one.
+    * waitFor('[data-e2e=history-item-' + analysisNewId + '].active')
+
+    # Switch to the older analysis.
+    * click('[data-e2e=history-set-current-' + analysisOldId + ']')
+    * retry().until(!exists('[data-e2e=history-drawer]'))
+
+    # Re-open History → the older one is now active.
+    * click('[data-e2e=history-btn]')
+    * waitFor('[data-e2e=history-item-' + analysisOldId + '].active')
+
+    * call read('classpath:common/helpers/cleanup-by-name.feature') { filename: 'small.pdf' }

--- a/frontend/src/features/chunks/store.ts
+++ b/frontend/src/features/chunks/store.ts
@@ -12,9 +12,21 @@ export const useChunksStore = defineStore('chunks', () => {
   const diffing = ref(false)
   const diff = ref<ChunkDiff[]>([])
   const error = ref<string | null>(null)
+  // 0.6.1 — Strategy popover open state (#268). Lifted to the store so
+  // either the in-panel `⚙ Strategy` button or the workspace-level
+  // `Generate chunks` button can open the same popover.
+  const strategyOpen = ref(false)
 
   function clearError(): void {
     error.value = null
+  }
+
+  function openStrategy(): void {
+    strategyOpen.value = true
+  }
+
+  function closeStrategy(): void {
+    strategyOpen.value = false
   }
 
   /** Pure derived getter — chunks whose `sourcePage` matches the given page. */
@@ -198,7 +210,10 @@ export const useChunksStore = defineStore('chunks', () => {
     diffing,
     diff,
     error,
+    strategyOpen,
     clearError,
+    openStrategy,
+    closeStrategy,
     load,
     rechunk,
     updateText,

--- a/frontend/src/features/chunks/ui/ChunksPanel.vue
+++ b/frontend/src/features/chunks/ui/ChunksPanel.vue
@@ -37,8 +37,26 @@
     <div v-else-if="chunksStore.error" class="chunks-panel-state chunks-panel-error">
       {{ chunksStore.error }}
     </div>
+    <div
+      v-else-if="!chunksStore.chunks.length"
+      class="chunks-panel-state chunks-panel-state--empty"
+      data-e2e="chunks-panel-empty"
+    >
+      <p>{{ t('chunk.panel.emptyAll') }}</p>
+      <button
+        type="button"
+        class="chunks-empty-cta"
+        :disabled="chunksStore.rechunking"
+        data-e2e="chunks-panel-empty-cta"
+        @click="openStrategy"
+      >
+        <span v-if="chunksStore.rechunking" class="spinner spinner--inline" />
+        <span v-else>⚙</span>
+        {{ chunksStore.rechunking ? t('strategy.rechunking') : t('chunk.panel.generate') }}
+      </button>
+    </div>
     <div v-else-if="!pageChunks.length" class="chunks-panel-state">
-      {{ t('linked.chunks.emptyOnPage', { page: currentPage }) }}
+      {{ t('chunk.panel.emptyOnPage', { page: currentPage }) }}
     </div>
 
     <ul v-else class="chunks-panel-list" data-e2e="chunks-panel-list">
@@ -226,6 +244,41 @@ void props.docId
   font-size: 12px;
   color: var(--text-muted);
   padding: 20px;
+  text-align: center;
+}
+
+.chunks-panel-state--empty {
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chunks-empty-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: white;
+  font-size: 12px;
+  cursor: pointer;
+  transition: filter var(--transition);
+}
+
+.chunks-empty-cta:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.chunks-empty-cta:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.spinner--inline {
+  width: 10px;
+  height: 10px;
+  border-width: 1.5px;
 }
 
 .chunks-panel-error {

--- a/frontend/src/features/chunks/ui/ChunksPanel.vue
+++ b/frontend/src/features/chunks/ui/ChunksPanel.vue
@@ -17,17 +17,17 @@
         :disabled="chunksStore.rechunking"
         :title="t('chunk.strategy')"
         data-e2e="strategy-btn"
-        @click="openStrategy"
+        @click="chunksStore.openStrategy"
       >
         ⚙ {{ t('chunk.strategy') }}
       </button>
     </header>
 
     <StrategyPopover
-      :open="strategyOpen"
+      :open="chunksStore.strategyOpen"
       :has-manual-edits="chunksStore.hasManualEdits"
       :rechunking="chunksStore.rechunking"
-      @close="strategyOpen = false"
+      @close="chunksStore.closeStrategy"
       @apply="onApplyStrategy"
     />
 
@@ -39,21 +39,10 @@
     </div>
     <div
       v-else-if="!chunksStore.chunks.length"
-      class="chunks-panel-state chunks-panel-state--empty"
+      class="chunks-panel-state"
       data-e2e="chunks-panel-empty"
     >
-      <p>{{ t('chunk.panel.emptyAll') }}</p>
-      <button
-        type="button"
-        class="chunks-empty-cta"
-        :disabled="chunksStore.rechunking"
-        data-e2e="chunks-panel-empty-cta"
-        @click="openStrategy"
-      >
-        <span v-if="chunksStore.rechunking" class="spinner spinner--inline" />
-        <span v-else>⚙</span>
-        {{ chunksStore.rechunking ? t('strategy.rechunking') : t('chunk.panel.generate') }}
-      </button>
+      {{ t('chunk.panel.emptyAll') }}
     </div>
     <div v-else-if="!pageChunks.length" class="chunks-panel-state">
       {{ t('chunk.panel.emptyOnPage', { page: currentPage }) }}
@@ -111,7 +100,7 @@
  * The Strategy button is rendered as disabled with a tooltip until
  * T7 (#268) wires the rechunk popover.
  */
-import { computed, ref, watch } from 'vue'
+import { computed, watch } from 'vue'
 import type { DocChunk } from '../../../shared/types'
 import type { RechunkOptions } from '../../document/api'
 import { useI18n } from '../../../shared/i18n'
@@ -136,17 +125,12 @@ const chunksStore = useChunksStore()
 
 const pageChunks = computed<DocChunk[]>(() => chunksStore.chunksOnPage(props.currentPage))
 
-// Strategy popover (#268) — anchored inline; the chunks store handles
-// the actual rechunk call so its state survives popover dismissal.
-const strategyOpen = ref(false)
-
-function openStrategy(): void {
-  strategyOpen.value = true
-}
-
+// Strategy popover open state is owned by `chunksStore` so the
+// workspace-level `Generate chunks` button (#266) can open the same
+// popover. Apply still routes through the panel for the rechunk call.
 async function onApplyStrategy(options: RechunkOptions): Promise<void> {
   const ok = await chunksStore.rechunk(props.docId, options)
-  if (ok) strategyOpen.value = false
+  if (ok) chunksStore.closeStrategy()
 }
 
 const cardRefs = new Map<string, HTMLElement>()
@@ -232,8 +216,18 @@ void props.docId
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
-  cursor: not-allowed;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.strategy-btn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.strategy-btn:disabled {
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .chunks-panel-state {
@@ -245,40 +239,6 @@ void props.docId
   color: var(--text-muted);
   padding: 20px;
   text-align: center;
-}
-
-.chunks-panel-state--empty {
-  flex-direction: column;
-  gap: 12px;
-}
-
-.chunks-empty-cta {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 14px;
-  background: var(--accent);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-sm);
-  color: white;
-  font-size: 12px;
-  cursor: pointer;
-  transition: filter var(--transition);
-}
-
-.chunks-empty-cta:hover:not(:disabled) {
-  filter: brightness(1.1);
-}
-
-.chunks-empty-cta:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
-}
-
-.spinner--inline {
-  width: 10px;
-  height: 10px;
-  border-width: 1.5px;
 }
 
 .chunks-panel-error {

--- a/frontend/src/features/document/api.ts
+++ b/frontend/src/features/document/api.ts
@@ -1,4 +1,4 @@
-import type { DocChunk, Document, DocTreeNode } from '../../shared/types'
+import type { DocChunk, Document, DocTreeNode, DocumentVersion } from '../../shared/types'
 import { apiFetch } from '../../shared/api/http'
 
 export function fetchDocuments(): Promise<Document[]> {
@@ -52,4 +52,17 @@ export function rechunkDocument(id: string, options?: RechunkOptions): Promise<D
 
 export function fetchDocumentTree(id: string): Promise<DocTreeNode[]> {
   return apiFetch<DocTreeNode[]>(`/api/documents/${id}/tree`)
+}
+
+/** Workspace History timeline (#267) — frozen pairs newest-first. */
+export function fetchDocumentVersions(id: string): Promise<DocumentVersion[]> {
+  return apiFetch<DocumentVersion[]>(`/api/documents/${id}/versions`)
+}
+
+/** Restore a version — overwrites the live chunkset with the snapshot. */
+export function restoreDocumentVersion(docId: string, versionId: string): Promise<DocumentVersion> {
+  return apiFetch<DocumentVersion>(`/api/documents/${docId}/versions/${versionId}/restore`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
 }

--- a/frontend/src/features/document/store.test.ts
+++ b/frontend/src/features/document/store.test.ts
@@ -8,6 +8,8 @@ vi.mock('./api', () => ({
   uploadDocument: vi.fn(),
   deleteDocument: vi.fn(),
   rechunkDocument: vi.fn(),
+  fetchDocumentVersions: vi.fn(),
+  restoreDocumentVersion: vi.fn(),
 }))
 
 vi.mock('../chunks/api', () => ({
@@ -15,7 +17,7 @@ vi.mock('../chunks/api', () => ({
 }))
 
 vi.mock('../analysis/api', () => ({
-  fetchDocumentAnalyses: vi.fn(),
+  fetchAnalysis: vi.fn(),
 }))
 
 import * as api from './api'
@@ -184,38 +186,71 @@ describe('useDocumentStore', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // loadWorkspace (#264) — Linked view orchestration
+  // loadWorkspace (#264 / #267) — versioned (analysis, chunks) timeline
   // ---------------------------------------------------------------------------
 
-  it('loadWorkspace() loads doc + picks the latest completed analysis', async () => {
+  const mkVersion = (overrides = {}) => ({
+    id: 'v1',
+    documentId: 'd1',
+    kind: 'analysis' as const,
+    analysisId: 'a1',
+    chunksSnapshotSize: 0,
+    summary: 'Analysis run',
+    createdAt: '2025-02-01T00:00:00Z',
+    ...overrides,
+  })
+
+  const mkAnalysis = (overrides = {}) => ({
+    id: 'a1',
+    documentId: 'd1',
+    documentFilename: 'a.pdf',
+    status: 'COMPLETED' as const,
+    contentMarkdown: null,
+    contentHtml: null,
+    pagesJson: '[]',
+    chunksJson: null,
+    hasDocumentJson: true,
+    errorMessage: null,
+    progressCurrent: null,
+    progressTotal: null,
+    startedAt: null,
+    completedAt: '2025-02-01T00:00:00Z',
+    createdAt: '2025-02-01T00:00:00Z',
+    ...overrides,
+  })
+
+  it('loadWorkspace() loads doc + auto-pins the latest version + fetches its analysis', async () => {
     api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      { id: 'a-old', status: 'COMPLETED', completedAt: '2025-01-01T00:00:00Z', pagesJson: '[]' },
-      { id: 'a-new', status: 'COMPLETED', completedAt: '2025-02-01T00:00:00Z', pagesJson: '[]' },
-      { id: 'a-pending', status: 'PENDING', completedAt: null, pagesJson: null },
+    api.fetchDocumentVersions.mockResolvedValue([
+      mkVersion({ id: 'v-new', createdAt: '2025-02-01T00:00:00Z' }),
+      mkVersion({ id: 'v-old', createdAt: '2025-01-01T00:00:00Z' }),
     ])
+    analysisApi.fetchAnalysis.mockResolvedValue(mkAnalysis())
+
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
+
     expect(store.workspaceDoc?.id).toBe('d1')
-    expect(store.workspaceLatestAnalysis?.id).toBe('a-new')
+    expect(store.workspaceCurrentVersionId).toBe('v-new')
+    expect(store.workspaceVersions.map((v) => v.id)).toEqual(['v-new', 'v-old'])
+    expect(store.workspaceLatestAnalysis?.id).toBe('a1')
     expect(store.workspaceLoading).toBe(false)
     expect(store.workspaceError).toBeNull()
   })
 
-  it('loadWorkspace() exposes null analysis when none completed', async () => {
+  it('loadWorkspace() exposes null active analysis when no versions exist', async () => {
     api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      { id: 'a1', status: 'PENDING', completedAt: null, pagesJson: null },
-    ])
+    api.fetchDocumentVersions.mockResolvedValue([])
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
+    expect(store.workspaceCurrentVersionId).toBeNull()
     expect(store.workspaceLatestAnalysis).toBeNull()
     expect(store.workspacePages).toEqual([])
   })
 
   it('loadWorkspace() sets workspaceError on failure', async () => {
     api.fetchDocument.mockRejectedValue(new Error('boom'))
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([])
+    api.fetchDocumentVersions.mockResolvedValue([])
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
     expect(store.workspaceError).toBe('boom')
@@ -224,14 +259,12 @@ describe('useDocumentStore', () => {
 
   it('workspacePages parses pages_json lazily, empty on parse error', async () => {
     api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      {
-        id: 'a1',
-        status: 'COMPLETED',
-        completedAt: '2025-02-01T00:00:00Z',
+    api.fetchDocumentVersions.mockResolvedValue([mkVersion()])
+    analysisApi.fetchAnalysis.mockResolvedValue(
+      mkAnalysis({
         pagesJson: '[{"page_number":1,"width":600,"height":800,"elements":[]}]',
-      },
-    ])
+      }),
+    )
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
     expect(store.workspacePages).toHaveLength(1)
@@ -239,113 +272,84 @@ describe('useDocumentStore', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // History drawer (#267) — workspaceAnalyses + setWorkspaceAnalysis
+  // setWorkspaceVersion — restore path
   // ---------------------------------------------------------------------------
 
-  it('loadWorkspace() exposes the full analyses list, newest first', async () => {
+  it('setWorkspaceVersion() POSTs restore + swaps the active version + analysis', async () => {
     api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      {
-        id: 'a-old',
-        status: 'COMPLETED',
-        completedAt: '2025-01-01T00:00:00Z',
-        createdAt: '2025-01-01T00:00:00Z',
-        pagesJson: '[]',
-      },
-      {
-        id: 'a-pending',
-        status: 'PENDING',
-        completedAt: null,
-        createdAt: '2025-03-01T00:00:00Z',
-        pagesJson: null,
-      },
-      {
-        id: 'a-new',
-        status: 'COMPLETED',
-        completedAt: '2025-02-01T00:00:00Z',
-        createdAt: '2025-02-01T00:00:00Z',
-        pagesJson: '[]',
-      },
+    api.fetchDocumentVersions.mockResolvedValue([
+      mkVersion({ id: 'v-new', analysisId: 'a-new' }),
+      mkVersion({ id: 'v-old', analysisId: 'a-old' }),
     ])
+    analysisApi.fetchAnalysis.mockImplementation((id: string) =>
+      Promise.resolve(mkAnalysis({ id })),
+    )
+    api.restoreDocumentVersion.mockResolvedValue(mkVersion({ id: 'v-old' }))
+
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
-    // Sort key falls back to createdAt for non-completed entries: the
-    // PENDING analysis (createdAt 2025-03-01) wins over the COMPLETED
-    // a-new (completedAt 2025-02-01).
-    expect(store.workspaceAnalyses.map((a) => a.id)).toEqual(['a-pending', 'a-new', 'a-old'])
-    // …but the auto-picked current is the latest COMPLETED, not the
-    // PENDING one.
-    expect(store.workspaceCurrentAnalysisId).toBe('a-new')
+    expect(store.workspaceCurrentVersionId).toBe('v-new')
+
+    const ok = await store.setWorkspaceVersion('v-old')
+    expect(ok).toBe(true)
+    expect(api.restoreDocumentVersion).toHaveBeenCalledWith('d1', 'v-old')
+    expect(store.workspaceCurrentVersionId).toBe('v-old')
+    expect(store.workspaceActiveAnalysis?.id).toBe('a-old')
   })
 
-  it('setWorkspaceAnalysis() switches the active analysis when the id is known', async () => {
+  it('setWorkspaceVersion() returns false for unknown ids and leaves state intact', async () => {
     api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      {
-        id: 'a-new',
-        status: 'COMPLETED',
-        completedAt: '2025-02-01T00:00:00Z',
-        createdAt: '2025-02-01T00:00:00Z',
-        pagesJson: '[]',
-      },
-      {
-        id: 'a-old',
-        status: 'COMPLETED',
-        completedAt: '2025-01-01T00:00:00Z',
-        createdAt: '2025-01-01T00:00:00Z',
-        pagesJson: '[]',
-      },
-    ])
+    api.fetchDocumentVersions.mockResolvedValue([mkVersion({ id: 'v1' })])
+    analysisApi.fetchAnalysis.mockResolvedValue(mkAnalysis())
+
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
-    expect(store.workspaceCurrentAnalysisId).toBe('a-new')
-    store.setWorkspaceAnalysis('a-old')
-    expect(store.workspaceCurrentAnalysisId).toBe('a-old')
-    expect(store.workspaceLatestAnalysis?.id).toBe('a-old')
+    const ok = await store.setWorkspaceVersion('nope')
+    expect(ok).toBe(false)
+    expect(store.workspaceCurrentVersionId).toBe('v1')
   })
 
-  it('setWorkspaceAnalysis() is a no-op for unknown ids', async () => {
+  it('loadWorkspace() is idempotent — pinned version survives a second call for the same doc', async () => {
     api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      {
-        id: 'a1',
-        status: 'COMPLETED',
-        completedAt: '2025-02-01T00:00:00Z',
-        createdAt: '2025-02-01T00:00:00Z',
-        pagesJson: '[]',
-      },
+    api.fetchDocumentVersions.mockResolvedValue([
+      mkVersion({ id: 'v-new', analysisId: 'a-new' }),
+      mkVersion({ id: 'v-old', analysisId: 'a-old' }),
     ])
-    const store = useDocumentStore()
-    await store.loadWorkspace('d1')
-    store.setWorkspaceAnalysis('not-in-the-list')
-    expect(store.workspaceCurrentAnalysisId).toBe('a1')
-  })
+    analysisApi.fetchAnalysis.mockImplementation((id: string) =>
+      Promise.resolve(mkAnalysis({ id })),
+    )
+    api.restoreDocumentVersion.mockResolvedValue(mkVersion({ id: 'v-old' }))
 
-  it('loadWorkspace() is idempotent — pinned analysis survives a second call for the same doc', async () => {
-    api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
-    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
-      {
-        id: 'a-new',
-        status: 'COMPLETED',
-        completedAt: '2025-02-01T00:00:00Z',
-        createdAt: '2025-02-01T00:00:00Z',
-        pagesJson: '[]',
-      },
-      {
-        id: 'a-old',
-        status: 'COMPLETED',
-        completedAt: '2025-01-01T00:00:00Z',
-        createdAt: '2025-01-01T00:00:00Z',
-        pagesJson: '[]',
-      },
-    ])
     const store = useDocumentStore()
     await store.loadWorkspace('d1')
-    store.setWorkspaceAnalysis('a-old')
-    // Mimics switching from Parse to Chunk, which re-mounts and calls
-    // loadWorkspace again with the same docId.
+    await store.setWorkspaceVersion('v-old')
+    // Mimics switching tabs — second loadWorkspace must be a no-op.
     await store.loadWorkspace('d1')
-    expect(store.workspaceCurrentAnalysisId).toBe('a-old')
+    expect(store.workspaceCurrentVersionId).toBe('v-old')
     expect(api.fetchDocument).toHaveBeenCalledTimes(1)
+  })
+
+  // ---------------------------------------------------------------------------
+  // reloadWorkspaceVersions — post-completion refresh
+  // ---------------------------------------------------------------------------
+
+  it('reloadWorkspaceVersions() refreshes the list + auto-pins the newest', async () => {
+    api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
+    api.fetchDocumentVersions.mockResolvedValueOnce([mkVersion({ id: 'v1', analysisId: 'a1' })])
+    analysisApi.fetchAnalysis.mockResolvedValue(mkAnalysis({ id: 'a1' }))
+
+    const store = useDocumentStore()
+    await store.loadWorkspace('d1')
+    expect(store.workspaceCurrentVersionId).toBe('v1')
+
+    api.fetchDocumentVersions.mockResolvedValueOnce([
+      mkVersion({ id: 'v2', analysisId: 'a2', createdAt: '2025-03-01T00:00:00Z' }),
+      mkVersion({ id: 'v1', analysisId: 'a1' }),
+    ])
+    analysisApi.fetchAnalysis.mockResolvedValue(mkAnalysis({ id: 'a2' }))
+
+    await store.reloadWorkspaceVersions('d1')
+    expect(store.workspaceCurrentVersionId).toBe('v2')
+    expect(store.workspaceActiveAnalysis?.id).toBe('a2')
   })
 })

--- a/frontend/src/features/document/store.test.ts
+++ b/frontend/src/features/document/store.test.ts
@@ -237,4 +237,115 @@ describe('useDocumentStore', () => {
     expect(store.workspacePages).toHaveLength(1)
     expect(store.workspacePages[0].page_number).toBe(1)
   })
+
+  // ---------------------------------------------------------------------------
+  // History drawer (#267) — workspaceAnalyses + setWorkspaceAnalysis
+  // ---------------------------------------------------------------------------
+
+  it('loadWorkspace() exposes the full analyses list, newest first', async () => {
+    api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
+    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
+      {
+        id: 'a-old',
+        status: 'COMPLETED',
+        completedAt: '2025-01-01T00:00:00Z',
+        createdAt: '2025-01-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+      {
+        id: 'a-pending',
+        status: 'PENDING',
+        completedAt: null,
+        createdAt: '2025-03-01T00:00:00Z',
+        pagesJson: null,
+      },
+      {
+        id: 'a-new',
+        status: 'COMPLETED',
+        completedAt: '2025-02-01T00:00:00Z',
+        createdAt: '2025-02-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+    ])
+    const store = useDocumentStore()
+    await store.loadWorkspace('d1')
+    // Sort key falls back to createdAt for non-completed entries: the
+    // PENDING analysis (createdAt 2025-03-01) wins over the COMPLETED
+    // a-new (completedAt 2025-02-01).
+    expect(store.workspaceAnalyses.map((a) => a.id)).toEqual(['a-pending', 'a-new', 'a-old'])
+    // …but the auto-picked current is the latest COMPLETED, not the
+    // PENDING one.
+    expect(store.workspaceCurrentAnalysisId).toBe('a-new')
+  })
+
+  it('setWorkspaceAnalysis() switches the active analysis when the id is known', async () => {
+    api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
+    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
+      {
+        id: 'a-new',
+        status: 'COMPLETED',
+        completedAt: '2025-02-01T00:00:00Z',
+        createdAt: '2025-02-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+      {
+        id: 'a-old',
+        status: 'COMPLETED',
+        completedAt: '2025-01-01T00:00:00Z',
+        createdAt: '2025-01-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+    ])
+    const store = useDocumentStore()
+    await store.loadWorkspace('d1')
+    expect(store.workspaceCurrentAnalysisId).toBe('a-new')
+    store.setWorkspaceAnalysis('a-old')
+    expect(store.workspaceCurrentAnalysisId).toBe('a-old')
+    expect(store.workspaceLatestAnalysis?.id).toBe('a-old')
+  })
+
+  it('setWorkspaceAnalysis() is a no-op for unknown ids', async () => {
+    api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
+    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
+      {
+        id: 'a1',
+        status: 'COMPLETED',
+        completedAt: '2025-02-01T00:00:00Z',
+        createdAt: '2025-02-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+    ])
+    const store = useDocumentStore()
+    await store.loadWorkspace('d1')
+    store.setWorkspaceAnalysis('not-in-the-list')
+    expect(store.workspaceCurrentAnalysisId).toBe('a1')
+  })
+
+  it('loadWorkspace() is idempotent — pinned analysis survives a second call for the same doc', async () => {
+    api.fetchDocument.mockResolvedValue({ id: 'd1', filename: 'a.pdf' })
+    analysisApi.fetchDocumentAnalyses.mockResolvedValue([
+      {
+        id: 'a-new',
+        status: 'COMPLETED',
+        completedAt: '2025-02-01T00:00:00Z',
+        createdAt: '2025-02-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+      {
+        id: 'a-old',
+        status: 'COMPLETED',
+        completedAt: '2025-01-01T00:00:00Z',
+        createdAt: '2025-01-01T00:00:00Z',
+        pagesJson: '[]',
+      },
+    ])
+    const store = useDocumentStore()
+    await store.loadWorkspace('d1')
+    store.setWorkspaceAnalysis('a-old')
+    // Mimics switching from Parse to Chunk, which re-mounts and calls
+    // loadWorkspace again with the same docId.
+    await store.loadWorkspace('d1')
+    expect(store.workspaceCurrentAnalysisId).toBe('a-old')
+    expect(api.fetchDocument).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/src/features/document/store.ts
+++ b/frontend/src/features/document/store.ts
@@ -1,8 +1,8 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import type { Analysis, Document, Page } from '../../shared/types'
+import type { Analysis, Document, DocumentVersion, Page } from '../../shared/types'
 import { appMaxFileSizeMb } from '../../shared/appConfig'
-import { fetchDocumentAnalyses } from '../analysis/api'
+import { fetchAnalysis } from '../analysis/api'
 import { pushChunksToStore } from '../chunks/api'
 import * as api from './api'
 
@@ -12,30 +12,32 @@ export const useDocumentStore = defineStore('document', () => {
   const loading = ref(false)
   const uploading = ref(false)
   const error = ref<string | null>(null)
-  // 0.6.1 (#264, #267) — Doc workspace orchestration. Independent from
-  // the library listing above (documents/loading) so the two surfaces can
-  // be tested in isolation.
+  // 0.6.1 (#264, refactored #267) — Doc workspace orchestration. The
+  // workspace's History timeline is now versioned (frozen pairs of
+  // analysis + chunks snapshot). The active version drives the OCR
+  // side of the workspace (pagesJson, treeJson) — the chunks side is
+  // owned by `chunksStore`.
   const workspaceDoc = ref<Document | null>(null)
-  // Full analyses history for the current doc (#267). Sorted newest-first
-  // by completedAt (falling back to createdAt for non-completed entries).
-  const workspaceAnalyses = ref<Analysis[]>([])
-  // Currently-selected analysis id. Defaults to the latest COMPLETED on
-  // load; the History drawer (#267) can pin a different one.
-  const workspaceCurrentAnalysisId = ref<string | null>(null)
+  const workspaceVersions = ref<DocumentVersion[]>([])
+  const workspaceCurrentVersionId = ref<string | null>(null)
+  // Cached analysis row for the active version (analysisId resolution).
+  const workspaceActiveAnalysis = ref<Analysis | null>(null)
   const workspaceLoading = ref(false)
   const workspaceError = ref<string | null>(null)
 
-  /** The selected analysis for this workspace — auto-picked latest, or
-   *  the one the user pinned via the History drawer. */
-  const workspaceLatestAnalysis = computed<Analysis | null>(() => {
-    if (!workspaceCurrentAnalysisId.value) return null
-    return workspaceAnalyses.value.find((a) => a.id === workspaceCurrentAnalysisId.value) ?? null
+  const workspaceCurrentVersion = computed<DocumentVersion | null>(() => {
+    if (!workspaceCurrentVersionId.value) return null
+    return workspaceVersions.value.find((v) => v.id === workspaceCurrentVersionId.value) ?? null
   })
 
-  /** Pages parsed lazily from the selected analysis's `pagesJson`. Returns
-   *  an empty array on missing data or parse error — non-fatal. */
+  /** Backwards-compatible alias kept for existing consumers
+   * (DocParseTab, DocChunkTab) — semantically "the analysis row that
+   * powers the workspace right now". Resolved from the active version. */
+  const workspaceLatestAnalysis = computed<Analysis | null>(() => workspaceActiveAnalysis.value)
+
+  /** Pages parsed lazily from the active analysis's `pagesJson`. */
   const workspacePages = computed<Page[]>(() => {
-    const raw = workspaceLatestAnalysis.value?.pagesJson
+    const raw = workspaceActiveAnalysis.value?.pagesJson
     if (!raw) return []
     try {
       return JSON.parse(raw) as Page[]
@@ -110,41 +112,34 @@ export const useDocumentStore = defineStore('document', () => {
   }
 
   /**
-   * Doc workspace orchestration (#264, extended #267). Fetches the doc
-   * metadata and the doc's analyses in parallel — chunks are loaded by
-   * the chunks store independently so the two stores stay testable in
-   * isolation. Defaults the active analysis to the latest COMPLETED one;
-   * the History drawer can pin a different one via `setWorkspaceAnalysis`.
+   * Workspace orchestration (#267). Loads the doc + the versions
+   * timeline, auto-pins the most recent version, and resolves its
+   * analysis row so Parse / Chunk render the right OCR side.
    *
    * Idempotent across view switches: if the workspace is already loaded
    * for `docId`, returns immediately. This preserves a user-pinned
-   * analysis when the user switches between Parse and Chunk tabs.
-   * Reloading the analyses list is a separate concern handled by
-   * `reloadAnalyses(docId)`.
+   * version when the user switches between Parse and Chunk tabs.
    */
   async function loadWorkspace(docId: string): Promise<void> {
     if (workspaceDoc.value?.id === docId) return
     workspaceLoading.value = true
     workspaceError.value = null
     workspaceDoc.value = null
-    workspaceAnalyses.value = []
-    workspaceCurrentAnalysisId.value = null
+    workspaceVersions.value = []
+    workspaceCurrentVersionId.value = null
+    workspaceActiveAnalysis.value = null
     try {
-      const [doc, analyses] = await Promise.all([
+      const [doc, versions] = await Promise.all([
         api.fetchDocument(docId),
-        fetchDocumentAnalyses(docId),
+        api.fetchDocumentVersions(docId),
       ])
       workspaceDoc.value = doc
-      // Newest-first sort. Falls back to createdAt when completedAt is
-      // null (PENDING / RUNNING / FAILED entries still belong to history).
-      workspaceAnalyses.value = [...analyses].sort((a, b) =>
-        (b.completedAt ?? b.createdAt).localeCompare(a.completedAt ?? a.createdAt),
-      )
-      // Auto-pick the latest COMPLETED analysis as the active one. If
-      // none is completed yet, leave the workspace empty — Parse / Chunk
-      // already render an "Aucune analyse" state in that case.
-      workspaceCurrentAnalysisId.value =
-        workspaceAnalyses.value.find((a) => a.status === 'COMPLETED')?.id ?? null
+      workspaceVersions.value = versions
+      const latest = versions[0] ?? null
+      workspaceCurrentVersionId.value = latest?.id ?? null
+      if (latest?.analysisId) {
+        workspaceActiveAnalysis.value = await fetchAnalysis(latest.analysisId)
+      }
     } catch (e) {
       workspaceError.value = (e as Error).message || 'Failed to load workspace'
     } finally {
@@ -153,34 +148,49 @@ export const useDocumentStore = defineStore('document', () => {
   }
 
   /**
-   * Switch the active analysis without re-fetching the analyses list
-   * (#267). Caller code (DocParseTab / DocChunkTab) is responsible for
-   * reloading the chunks tied to the new analysis.
+   * Refresh the versions list without resetting the doc (#266 / #267).
+   * Called after a `+ New analysis` or `+ Generate chunks` completes —
+   * the backend appended a fresh version, we pin it as active.
    */
-  function setWorkspaceAnalysis(analysisId: string): void {
-    if (!workspaceAnalyses.value.some((a) => a.id === analysisId)) return
-    workspaceCurrentAnalysisId.value = analysisId
+  async function reloadWorkspaceVersions(docId: string): Promise<void> {
+    if (workspaceDoc.value?.id !== docId) return
+    try {
+      const versions = await api.fetchDocumentVersions(docId)
+      workspaceVersions.value = versions
+      const latest = versions[0] ?? null
+      if (latest) {
+        workspaceCurrentVersionId.value = latest.id
+        if (latest.analysisId) {
+          workspaceActiveAnalysis.value = await fetchAnalysis(latest.analysisId)
+        }
+      }
+    } catch (e) {
+      workspaceError.value = (e as Error).message || 'Failed to reload versions'
+    }
   }
 
   /**
-   * Refresh the analyses list without resetting the doc (#266). Called
-   * after an in-place analysis run completes so the new entry shows up
-   * in History and gets auto-pinned as the active one. Bypasses the
-   * idempotency guard on `loadWorkspace`.
+   * Pin a different version as the active one — calls the backend
+   * restore endpoint (which rewrites the live chunkset from the
+   * version's snapshot) and refreshes the active analysis row.
+   * Returns `true` on success so callers can update sibling state
+   * (e.g. reload the chunks store, scroll, close the drawer).
    */
-  async function reloadWorkspaceAnalyses(docId: string): Promise<void> {
-    if (workspaceDoc.value?.id !== docId) return
+  async function setWorkspaceVersion(versionId: string): Promise<boolean> {
+    const docId = workspaceDoc.value?.id
+    if (!docId) return false
+    const version = workspaceVersions.value.find((v) => v.id === versionId)
+    if (!version) return false
     try {
-      const analyses = await fetchDocumentAnalyses(docId)
-      workspaceAnalyses.value = [...analyses].sort((a, b) =>
-        (b.completedAt ?? b.createdAt).localeCompare(a.completedAt ?? a.createdAt),
-      )
-      // Auto-pin the latest COMPLETED so the workspace renders the
-      // freshly-finished analysis without a manual click in History.
-      const latestCompleted = workspaceAnalyses.value.find((a) => a.status === 'COMPLETED')
-      if (latestCompleted) workspaceCurrentAnalysisId.value = latestCompleted.id
+      await api.restoreDocumentVersion(docId, versionId)
+      workspaceCurrentVersionId.value = versionId
+      workspaceActiveAnalysis.value = version.analysisId
+        ? await fetchAnalysis(version.analysisId)
+        : null
+      return true
     } catch (e) {
-      workspaceError.value = (e as Error).message || 'Failed to reload analyses'
+      workspaceError.value = (e as Error).message || 'Failed to restore version'
+      return false
     }
   }
 
@@ -202,8 +212,10 @@ export const useDocumentStore = defineStore('document', () => {
     uploading,
     error,
     workspaceDoc,
-    workspaceAnalyses,
-    workspaceCurrentAnalysisId,
+    workspaceVersions,
+    workspaceCurrentVersionId,
+    workspaceCurrentVersion,
+    workspaceActiveAnalysis,
     workspaceLatestAnalysis,
     workspacePages,
     workspaceLoading,
@@ -211,8 +223,8 @@ export const useDocumentStore = defineStore('document', () => {
     clearError,
     load,
     loadWorkspace,
-    reloadWorkspaceAnalyses,
-    setWorkspaceAnalysis,
+    reloadWorkspaceVersions,
+    setWorkspaceVersion,
     upload,
     remove,
     select,

--- a/frontend/src/features/document/store.ts
+++ b/frontend/src/features/document/store.ts
@@ -162,6 +162,28 @@ export const useDocumentStore = defineStore('document', () => {
     workspaceCurrentAnalysisId.value = analysisId
   }
 
+  /**
+   * Refresh the analyses list without resetting the doc (#266). Called
+   * after an in-place analysis run completes so the new entry shows up
+   * in History and gets auto-pinned as the active one. Bypasses the
+   * idempotency guard on `loadWorkspace`.
+   */
+  async function reloadWorkspaceAnalyses(docId: string): Promise<void> {
+    if (workspaceDoc.value?.id !== docId) return
+    try {
+      const analyses = await fetchDocumentAnalyses(docId)
+      workspaceAnalyses.value = [...analyses].sort((a, b) =>
+        (b.completedAt ?? b.createdAt).localeCompare(a.completedAt ?? a.createdAt),
+      )
+      // Auto-pin the latest COMPLETED so the workspace renders the
+      // freshly-finished analysis without a manual click in History.
+      const latestCompleted = workspaceAnalyses.value.find((a) => a.status === 'COMPLETED')
+      if (latestCompleted) workspaceCurrentAnalysisId.value = latestCompleted.id
+    } catch (e) {
+      workspaceError.value = (e as Error).message || 'Failed to reload analyses'
+    }
+  }
+
   async function pushToStore(id: string, store: string): Promise<string | null> {
     try {
       const res = await pushChunksToStore(id, store)
@@ -189,6 +211,7 @@ export const useDocumentStore = defineStore('document', () => {
     clearError,
     load,
     loadWorkspace,
+    reloadWorkspaceAnalyses,
     setWorkspaceAnalysis,
     upload,
     remove,

--- a/frontend/src/features/document/store.ts
+++ b/frontend/src/features/document/store.ts
@@ -12,15 +12,27 @@ export const useDocumentStore = defineStore('document', () => {
   const loading = ref(false)
   const uploading = ref(false)
   const error = ref<string | null>(null)
-  // 0.6.1 (#264) — Linked view workspace orchestration. Independent from
+  // 0.6.1 (#264, #267) — Doc workspace orchestration. Independent from
   // the library listing above (documents/loading) so the two surfaces can
   // be tested in isolation.
   const workspaceDoc = ref<Document | null>(null)
-  const workspaceLatestAnalysis = ref<Analysis | null>(null)
+  // Full analyses history for the current doc (#267). Sorted newest-first
+  // by completedAt (falling back to createdAt for non-completed entries).
+  const workspaceAnalyses = ref<Analysis[]>([])
+  // Currently-selected analysis id. Defaults to the latest COMPLETED on
+  // load; the History drawer (#267) can pin a different one.
+  const workspaceCurrentAnalysisId = ref<string | null>(null)
   const workspaceLoading = ref(false)
   const workspaceError = ref<string | null>(null)
 
-  /** Pages parsed lazily from `workspaceLatestAnalysis.pagesJson`. Returns
+  /** The selected analysis for this workspace — auto-picked latest, or
+   *  the one the user pinned via the History drawer. */
+  const workspaceLatestAnalysis = computed<Analysis | null>(() => {
+    if (!workspaceCurrentAnalysisId.value) return null
+    return workspaceAnalyses.value.find((a) => a.id === workspaceCurrentAnalysisId.value) ?? null
+  })
+
+  /** Pages parsed lazily from the selected analysis's `pagesJson`. Returns
    *  an empty array on missing data or parse error — non-fatal. */
   const workspacePages = computed<Page[]>(() => {
     const raw = workspaceLatestAnalysis.value?.pagesJson
@@ -98,31 +110,56 @@ export const useDocumentStore = defineStore('document', () => {
   }
 
   /**
-   * Doc workspace orchestration (#264). Fetches the doc metadata and the
-   * latest completed analysis in parallel — chunks are loaded by the
-   * chunks store independently so the two stores stay testable in
-   * isolation.
+   * Doc workspace orchestration (#264, extended #267). Fetches the doc
+   * metadata and the doc's analyses in parallel — chunks are loaded by
+   * the chunks store independently so the two stores stay testable in
+   * isolation. Defaults the active analysis to the latest COMPLETED one;
+   * the History drawer can pin a different one via `setWorkspaceAnalysis`.
+   *
+   * Idempotent across view switches: if the workspace is already loaded
+   * for `docId`, returns immediately. This preserves a user-pinned
+   * analysis when the user switches between Parse and Chunk tabs.
+   * Reloading the analyses list is a separate concern handled by
+   * `reloadAnalyses(docId)`.
    */
   async function loadWorkspace(docId: string): Promise<void> {
+    if (workspaceDoc.value?.id === docId) return
     workspaceLoading.value = true
     workspaceError.value = null
     workspaceDoc.value = null
-    workspaceLatestAnalysis.value = null
+    workspaceAnalyses.value = []
+    workspaceCurrentAnalysisId.value = null
     try {
       const [doc, analyses] = await Promise.all([
         api.fetchDocument(docId),
         fetchDocumentAnalyses(docId),
       ])
       workspaceDoc.value = doc
-      workspaceLatestAnalysis.value =
-        analyses
-          .filter((a) => a.status === 'COMPLETED')
-          .sort((a, b) => (b.completedAt ?? '').localeCompare(a.completedAt ?? ''))[0] ?? null
+      // Newest-first sort. Falls back to createdAt when completedAt is
+      // null (PENDING / RUNNING / FAILED entries still belong to history).
+      workspaceAnalyses.value = [...analyses].sort((a, b) =>
+        (b.completedAt ?? b.createdAt).localeCompare(a.completedAt ?? a.createdAt),
+      )
+      // Auto-pick the latest COMPLETED analysis as the active one. If
+      // none is completed yet, leave the workspace empty — Parse / Chunk
+      // already render an "Aucune analyse" state in that case.
+      workspaceCurrentAnalysisId.value =
+        workspaceAnalyses.value.find((a) => a.status === 'COMPLETED')?.id ?? null
     } catch (e) {
       workspaceError.value = (e as Error).message || 'Failed to load workspace'
     } finally {
       workspaceLoading.value = false
     }
+  }
+
+  /**
+   * Switch the active analysis without re-fetching the analyses list
+   * (#267). Caller code (DocParseTab / DocChunkTab) is responsible for
+   * reloading the chunks tied to the new analysis.
+   */
+  function setWorkspaceAnalysis(analysisId: string): void {
+    if (!workspaceAnalyses.value.some((a) => a.id === analysisId)) return
+    workspaceCurrentAnalysisId.value = analysisId
   }
 
   async function pushToStore(id: string, store: string): Promise<string | null> {
@@ -143,6 +180,8 @@ export const useDocumentStore = defineStore('document', () => {
     uploading,
     error,
     workspaceDoc,
+    workspaceAnalyses,
+    workspaceCurrentAnalysisId,
     workspaceLatestAnalysis,
     workspacePages,
     workspaceLoading,
@@ -150,6 +189,7 @@ export const useDocumentStore = defineStore('document', () => {
     clearError,
     load,
     loadWorkspace,
+    setWorkspaceAnalysis,
     upload,
     remove,
     select,

--- a/frontend/src/features/document/ui/HistoryDrawer.vue
+++ b/frontend/src/features/document/ui/HistoryDrawer.vue
@@ -1,0 +1,264 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="history-backdrop"
+      data-e2e="history-backdrop"
+      @click.self="$emit('close')"
+    >
+      <aside
+        class="history-drawer"
+        role="dialog"
+        :aria-label="t('history.title')"
+        data-e2e="history-drawer"
+      >
+        <header class="history-header">
+          <h2 class="history-title">{{ t('history.title') }}</h2>
+          <button
+            type="button"
+            class="history-close"
+            :aria-label="t('history.close')"
+            @click="$emit('close')"
+          >
+            ×
+          </button>
+        </header>
+
+        <div v-if="!analyses.length" class="history-empty" data-e2e="history-empty">
+          {{ t('history.empty') }}
+        </div>
+
+        <ul v-else class="history-list" data-e2e="history-list">
+          <li
+            v-for="a in analyses"
+            :key="a.id"
+            class="history-item"
+            :class="{ active: a.id === currentId }"
+            :data-e2e="`history-item-${a.id}`"
+          >
+            <div class="history-item-head">
+              <span class="history-status" :class="`history-status--${a.status.toLowerCase()}`">
+                {{ a.status }}
+              </span>
+              <span class="history-time" :title="a.completedAt ?? a.createdAt">
+                {{ formatRelativeTime(a.completedAt ?? a.createdAt) }}
+              </span>
+            </div>
+            <div class="history-item-id">{{ a.id }}</div>
+            <div class="history-item-actions">
+              <span v-if="a.id === currentId" class="history-current-flag">
+                {{ t('history.current') }}
+              </span>
+              <button
+                v-else
+                type="button"
+                class="history-set-current"
+                :disabled="a.status !== 'COMPLETED'"
+                :title="a.status !== 'COMPLETED' ? t('history.notCompleted') : undefined"
+                :data-e2e="`history-set-current-${a.id}`"
+                @click="$emit('setCurrent', a.id)"
+              >
+                {{ t('history.setCurrent') }}
+              </button>
+            </div>
+          </li>
+        </ul>
+      </aside>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+/**
+ * History drawer (#267) — right-side panel listing every analysis run
+ * on the current document, newest first. Lets the user pin a different
+ * analysis as the workspace's active one via "Set as current".
+ *
+ * Set-as-current is disabled on non-COMPLETED analyses (PENDING,
+ * RUNNING, FAILED) — Parse / Chunk views can only render a completed
+ * analysis's pages_json.
+ *
+ * The actual switch is handled by the parent: this component only
+ * emits `setCurrent` with the analysis id.
+ */
+import type { Analysis } from '../../../shared/types'
+import { useI18n } from '../../../shared/i18n'
+import { formatRelativeTime } from '../../../shared/format'
+
+defineProps<{
+  open: boolean
+  analyses: readonly Analysis[]
+  currentId: string | null
+}>()
+
+defineEmits<{
+  close: []
+  setCurrent: [analysisId: string]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<style scoped>
+.history-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history-drawer {
+  width: 400px;
+  max-width: 92vw;
+  height: 100%;
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.3);
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.history-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  color: var(--text);
+}
+
+.history-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.history-close:hover {
+  color: var(--text);
+}
+
+.history-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 20px;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.history-item {
+  padding: 10px 12px;
+  margin-bottom: 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.history-item.active {
+  border-color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.history-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.history-status {
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: 'IBM Plex Mono', monospace;
+  letter-spacing: 0.04em;
+}
+
+.history-status--completed {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.history-status--pending,
+.history-status--running {
+  background: rgba(234, 179, 8, 0.15);
+  color: #eab308;
+}
+
+.history-status--failed {
+  background: rgba(220, 38, 38, 0.15);
+  color: #dc2626;
+}
+
+.history-time {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.history-item-id {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-item-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.history-current-flag {
+  font-size: 11px;
+  color: var(--accent);
+  font-style: italic;
+}
+
+.history-set-current {
+  padding: 4px 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.history-set-current:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.history-set-current:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/features/document/ui/HistoryDrawer.vue
+++ b/frontend/src/features/document/ui/HistoryDrawer.vue
@@ -24,39 +24,42 @@
           </button>
         </header>
 
-        <div v-if="!analyses.length" class="history-empty" data-e2e="history-empty">
+        <div v-if="!versions.length" class="history-empty" data-e2e="history-empty">
           {{ t('history.empty') }}
         </div>
 
         <ul v-else class="history-list" data-e2e="history-list">
           <li
-            v-for="a in analyses"
-            :key="a.id"
+            v-for="v in versions"
+            :key="v.id"
             class="history-item"
-            :class="{ active: a.id === currentId }"
-            :data-e2e="`history-item-${a.id}`"
+            :class="{ active: v.id === currentId }"
+            :data-e2e="`history-item-${v.id}`"
           >
             <div class="history-item-head">
-              <span class="history-status" :class="`history-status--${a.status.toLowerCase()}`">
-                {{ a.status }}
+              <span class="history-kind" :class="`history-kind--${v.kind}`">
+                {{ t(`history.kind.${v.kind}`) }}
               </span>
-              <span class="history-time" :title="a.completedAt ?? a.createdAt">
-                {{ formatRelativeTime(a.completedAt ?? a.createdAt) }}
+              <span class="history-time" :title="v.createdAt">
+                {{ formatRelativeTime(v.createdAt) }}
               </span>
             </div>
-            <div class="history-item-id">{{ a.id }}</div>
+            <div class="history-item-meta">
+              <span class="history-meta-line">{{ v.summary }}</span>
+              <span class="history-meta-line history-meta-mono">
+                {{ t('history.chunksCount', { n: v.chunksSnapshotSize }) }}
+              </span>
+            </div>
             <div class="history-item-actions">
-              <span v-if="a.id === currentId" class="history-current-flag">
+              <span v-if="v.id === currentId" class="history-current-flag">
                 {{ t('history.current') }}
               </span>
               <button
                 v-else
                 type="button"
                 class="history-set-current"
-                :disabled="a.status !== 'COMPLETED'"
-                :title="a.status !== 'COMPLETED' ? t('history.notCompleted') : undefined"
-                :data-e2e="`history-set-current-${a.id}`"
-                @click="$emit('setCurrent', a.id)"
+                :data-e2e="`history-set-current-${v.id}`"
+                @click="$emit('setCurrent', v.id)"
               >
                 {{ t('history.setCurrent') }}
               </button>
@@ -70,30 +73,28 @@
 
 <script setup lang="ts">
 /**
- * History drawer (#267) — right-side panel listing every analysis run
- * on the current document, newest first. Lets the user pin a different
- * analysis as the workspace's active one via "Set as current".
- *
- * Set-as-current is disabled on non-COMPLETED analyses (PENDING,
- * RUNNING, FAILED) — Parse / Chunk views can only render a completed
- * analysis's pages_json.
+ * History drawer (#267) — right-side panel listing every frozen
+ * (analysis, chunks) version of the current document, newest first.
+ * Lets the user pin a different version via "Set as current", which
+ * routes to the backend restore endpoint (rewrites the live chunkset
+ * from the version's snapshot).
  *
  * The actual switch is handled by the parent: this component only
- * emits `setCurrent` with the analysis id.
+ * emits `setCurrent` with the version id.
  */
-import type { Analysis } from '../../../shared/types'
+import type { DocumentVersion } from '../../../shared/types'
 import { useI18n } from '../../../shared/i18n'
 import { formatRelativeTime } from '../../../shared/format'
 
 defineProps<{
   open: boolean
-  analyses: readonly Analysis[]
+  versions: readonly DocumentVersion[]
   currentId: string | null
 }>()
 
 defineEmits<{
   close: []
-  setCurrent: [analysisId: string]
+  setCurrent: [versionId: string]
 }>()
 
 const { t } = useI18n()
@@ -158,6 +159,7 @@ const { t } = useI18n()
   color: var(--text-muted);
   font-size: 12px;
   padding: 20px;
+  text-align: center;
 }
 
 .history-list {
@@ -190,29 +192,24 @@ const { t } = useI18n()
   gap: 8px;
 }
 
-.history-status {
+.history-kind {
   padding: 2px 8px;
   border-radius: 4px;
   font-size: 10px;
   font-weight: 600;
   font-family: 'IBM Plex Mono', monospace;
   letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.history-status--completed {
-  background: rgba(34, 197, 94, 0.15);
-  color: #22c55e;
+.history-kind--analysis {
+  background: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
 }
 
-.history-status--pending,
-.history-status--running {
-  background: rgba(234, 179, 8, 0.15);
-  color: #eab308;
-}
-
-.history-status--failed {
-  background: rgba(220, 38, 38, 0.15);
-  color: #dc2626;
+.history-kind--chunks {
+  background: rgba(139, 92, 246, 0.15);
+  color: #8b5cf6;
 }
 
 .history-time {
@@ -221,13 +218,20 @@ const { t } = useI18n()
   font-family: 'IBM Plex Mono', monospace;
 }
 
-.history-item-id {
+.history-item-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.history-meta-line {
   font-size: 11px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
+}
+
+.history-meta-mono {
   font-family: 'IBM Plex Mono', monospace;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  color: var(--text-muted);
 }
 
 .history-item-actions {
@@ -252,13 +256,8 @@ const { t } = useI18n()
   transition: all var(--transition);
 }
 
-.history-set-current:hover:not(:disabled) {
+.history-set-current:hover {
   color: var(--accent);
   border-color: var(--accent);
-}
-
-.history-set-current:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
 }
 </style>

--- a/frontend/src/pages/DocChunkTab.vue
+++ b/frontend/src/pages/DocChunkTab.vue
@@ -24,8 +24,16 @@
         <div v-else-if="documentStore.workspaceLoading" class="chunk-state">
           <span class="spinner" />
         </div>
-        <div v-else class="chunk-state">
-          {{ t('chunk.noAnalysis') }}
+        <div v-else class="chunk-state chunk-state--empty">
+          <p>{{ t('chunk.noAnalysis') }}</p>
+          <button
+            type="button"
+            class="chunk-state-cta"
+            data-e2e="chunk-empty-cta"
+            @click="onLaunchAnalysis"
+          >
+            + {{ t('newAnalysis.title') }}
+          </button>
         </div>
       </div>
       <aside class="chunk-aside">
@@ -57,6 +65,7 @@
  * hover/selection — keeps `BboxCanvas` and `ChunksPanel` decoupled.
  */
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import type { DocStoreLink, PageElement } from '../shared/types'
 import { useChunksStore } from '../features/chunks/store'
 import { useDocumentStore } from '../features/document/store'
@@ -66,6 +75,7 @@ import PagePreviewWithOverlay from '../features/document/ui/PagePreviewWithOverl
 import ChunksPanel from '../features/chunks/ui/ChunksPanel.vue'
 import StaleStoresStrip from '../features/chunks/ui/StaleStoresStrip.vue'
 import { useI18n } from '../shared/i18n'
+import { ROUTES } from '../shared/routing/names'
 
 const props = defineProps<{
   docId: string
@@ -74,8 +84,13 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const router = useRouter()
 const documentStore = useDocumentStore()
 const chunksStore = useChunksStore()
+
+function onLaunchAnalysis(): void {
+  router.push({ name: ROUTES.STUDIO, query: { docId: props.docId } })
+}
 
 const currentPage = ref(1)
 const hiddenTypes = ref<Set<string>>(new Set())
@@ -160,6 +175,26 @@ watch(
   justify-content: center;
   color: var(--text-muted);
   font-size: 13px;
+}
+
+.chunk-state--empty {
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chunk-state-cta {
+  padding: 6px 14px;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: white;
+  font-size: 12px;
+  cursor: pointer;
+  transition: filter var(--transition);
+}
+
+.chunk-state-cta:hover {
+  filter: brightness(1.1);
 }
 
 .chunk-aside {

--- a/frontend/src/pages/DocChunkTab.vue
+++ b/frontend/src/pages/DocChunkTab.vue
@@ -29,10 +29,13 @@
           <button
             type="button"
             class="chunk-state-cta"
+            :disabled="analysisStore.running"
             data-e2e="chunk-empty-cta"
             @click="onLaunchAnalysis"
           >
-            + {{ t('newAnalysis.title') }}
+            <span v-if="analysisStore.running" class="cta-spinner" />
+            <span v-else>+</span>
+            {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
           </button>
         </div>
       </div>
@@ -65,8 +68,8 @@
  * hover/selection — keeps `BboxCanvas` and `ChunksPanel` decoupled.
  */
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
 import type { DocStoreLink, PageElement } from '../shared/types'
+import { useAnalysisStore } from '../features/analysis/store'
 import { useChunksStore } from '../features/chunks/store'
 import { useDocumentStore } from '../features/document/store'
 import { chunkForElement, elementRefsForChunk } from '../features/document/linkedView'
@@ -75,7 +78,6 @@ import PagePreviewWithOverlay from '../features/document/ui/PagePreviewWithOverl
 import ChunksPanel from '../features/chunks/ui/ChunksPanel.vue'
 import StaleStoresStrip from '../features/chunks/ui/StaleStoresStrip.vue'
 import { useI18n } from '../shared/i18n'
-import { ROUTES } from '../shared/routing/names'
 
 const props = defineProps<{
   docId: string
@@ -84,12 +86,13 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const router = useRouter()
 const documentStore = useDocumentStore()
 const chunksStore = useChunksStore()
+const analysisStore = useAnalysisStore()
 
-function onLaunchAnalysis(): void {
-  router.push({ name: ROUTES.STUDIO, query: { docId: props.docId } })
+async function onLaunchAnalysis(): Promise<void> {
+  if (analysisStore.running) return
+  await analysisStore.run(props.docId)
 }
 
 const currentPage = ref(1)
@@ -183,6 +186,9 @@ watch(
 }
 
 .chunk-state-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 14px;
   background: var(--accent);
   border: 1px solid var(--accent);
@@ -193,8 +199,22 @@ watch(
   transition: filter var(--transition);
 }
 
-.chunk-state-cta:hover {
+.chunk-state-cta:hover:not(:disabled) {
   filter: brightness(1.1);
+}
+
+.chunk-state-cta:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.cta-spinner {
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
 }
 
 .chunk-aside {

--- a/frontend/src/pages/DocParseTab.vue
+++ b/frontend/src/pages/DocParseTab.vue
@@ -48,8 +48,16 @@
         <div v-else-if="documentStore.workspaceLoading" class="parse-state">
           <span class="spinner" />
         </div>
-        <div v-else class="parse-state">
-          {{ t('parse.noAnalysis') }}
+        <div v-else class="parse-state parse-state--empty">
+          <p>{{ t('parse.noAnalysis') }}</p>
+          <button
+            type="button"
+            class="parse-state-cta"
+            data-e2e="parse-empty-cta"
+            @click="onLaunchAnalysis"
+          >
+            + {{ t('newAnalysis.title') }}
+          </button>
         </div>
       </div>
       <ElementProperties
@@ -78,6 +86,7 @@
  *   - Clicking a bbox → select the matching node in the tree
  */
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import type { DocChunk, DocTreeNode, PageElement } from '../shared/types'
 import { useChunksStore } from '../features/chunks/store'
 import { fetchDocumentTree } from '../features/document/api'
@@ -88,12 +97,18 @@ import ElementProperties from '../features/document/ui/ElementProperties.vue'
 import LayersBar from '../features/document/ui/LayersBar.vue'
 import PagePreviewWithOverlay from '../features/document/ui/PagePreviewWithOverlay.vue'
 import { useI18n } from '../shared/i18n'
+import { ROUTES } from '../shared/routing/names'
 
 const props = defineProps<{ docId: string }>()
 
 const { t } = useI18n()
+const router = useRouter()
 const documentStore = useDocumentStore()
 const chunksStore = useChunksStore()
+
+function onLaunchAnalysis(): void {
+  router.push({ name: ROUTES.STUDIO, query: { docId: props.docId } })
+}
 
 const currentPage = ref(1)
 const hiddenTypes = ref<Set<string>>(new Set())
@@ -302,6 +317,26 @@ function findPageOfRef(
   justify-content: center;
   color: var(--text-muted);
   font-size: 13px;
+}
+
+.parse-state--empty {
+  flex-direction: column;
+  gap: 12px;
+}
+
+.parse-state-cta {
+  padding: 6px 14px;
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: white;
+  font-size: 12px;
+  cursor: pointer;
+  transition: filter var(--transition);
+}
+
+.parse-state-cta:hover {
+  filter: brightness(1.1);
 }
 
 .spinner {

--- a/frontend/src/pages/DocParseTab.vue
+++ b/frontend/src/pages/DocParseTab.vue
@@ -215,13 +215,13 @@ watch(
   },
 )
 
-// Refetch the tree when the active analysis changes (#266). Triggered
-// after an in-place analysis completes — the workspace watcher updates
-// `workspaceCurrentAnalysisId`, and the tree is built server-side from
-// the active analysis's `document_json`, so it has to be reloaded. Also
-// fires when the user pins a different analysis from the History drawer.
+// Refetch the tree when the active analysis changes (#266 / #267).
+// Triggered after an in-place analysis completes or after the user
+// restores a different version from the History drawer — the tree
+// is built server-side from the active analysis's `document_json`,
+// so it has to be reloaded.
 watch(
-  () => documentStore.workspaceCurrentAnalysisId,
+  () => documentStore.workspaceActiveAnalysis?.id,
   (newId, oldId) => {
     if (newId && newId !== oldId) {
       selectedNodeRef.value = null

--- a/frontend/src/pages/DocParseTab.vue
+++ b/frontend/src/pages/DocParseTab.vue
@@ -53,10 +53,13 @@
           <button
             type="button"
             class="parse-state-cta"
+            :disabled="analysisStore.running"
             data-e2e="parse-empty-cta"
             @click="onLaunchAnalysis"
           >
-            + {{ t('newAnalysis.title') }}
+            <span v-if="analysisStore.running" class="cta-spinner" />
+            <span v-else>+</span>
+            {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
           </button>
         </div>
       </div>
@@ -86,8 +89,8 @@
  *   - Clicking a bbox → select the matching node in the tree
  */
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
 import type { DocChunk, DocTreeNode, PageElement } from '../shared/types'
+import { useAnalysisStore } from '../features/analysis/store'
 import { useChunksStore } from '../features/chunks/store'
 import { fetchDocumentTree } from '../features/document/api'
 import { useDocumentStore } from '../features/document/store'
@@ -97,17 +100,17 @@ import ElementProperties from '../features/document/ui/ElementProperties.vue'
 import LayersBar from '../features/document/ui/LayersBar.vue'
 import PagePreviewWithOverlay from '../features/document/ui/PagePreviewWithOverlay.vue'
 import { useI18n } from '../shared/i18n'
-import { ROUTES } from '../shared/routing/names'
 
 const props = defineProps<{ docId: string }>()
 
 const { t } = useI18n()
-const router = useRouter()
 const documentStore = useDocumentStore()
 const chunksStore = useChunksStore()
+const analysisStore = useAnalysisStore()
 
-function onLaunchAnalysis(): void {
-  router.push({ name: ROUTES.STUDIO, query: { docId: props.docId } })
+async function onLaunchAnalysis(): Promise<void> {
+  if (analysisStore.running) return
+  await analysisStore.run(props.docId)
 }
 
 const currentPage = ref(1)
@@ -325,6 +328,9 @@ function findPageOfRef(
 }
 
 .parse-state-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 14px;
   background: var(--accent);
   border: 1px solid var(--accent);
@@ -335,8 +341,22 @@ function findPageOfRef(
   transition: filter var(--transition);
 }
 
-.parse-state-cta:hover {
+.parse-state-cta:hover:not(:disabled) {
   filter: brightness(1.1);
+}
+
+.parse-state-cta:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.cta-spinner {
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
 }
 
 .spinner {

--- a/frontend/src/pages/DocParseTab.vue
+++ b/frontend/src/pages/DocParseTab.vue
@@ -215,6 +215,21 @@ watch(
   },
 )
 
+// Refetch the tree when the active analysis changes (#266). Triggered
+// after an in-place analysis completes — the workspace watcher updates
+// `workspaceCurrentAnalysisId`, and the tree is built server-side from
+// the active analysis's `document_json`, so it has to be reloaded. Also
+// fires when the user pins a different analysis from the History drawer.
+watch(
+  () => documentStore.workspaceCurrentAnalysisId,
+  (newId, oldId) => {
+    if (newId && newId !== oldId) {
+      selectedNodeRef.value = null
+      loadTree()
+    }
+  },
+)
+
 // --- pure helpers ----------------------------------------------------------
 
 function countNodes(nodes: readonly DocTreeNode[]): number {

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -148,9 +148,11 @@ async function onNewAnalysis(): Promise<void> {
 
 // Watch analysisStore.running: when the in-place launch wraps up and
 // the polling sees a COMPLETED status, refresh the workspace analyses
-// list (the new run shows up in History + becomes the active one) and
-// reload the chunks (the analysis promoter on the backend just wrote
-// the canonical chunkset for the first analysis).
+// list (the new run shows up in History + becomes the active one).
+// Chunks are NOT reloaded here — running an analysis no longer creates
+// chunks (the backend auto-promoter was disabled in 0.6.1). The user
+// must explicitly invoke the Strategy popover from the Chunk view to
+// generate / regenerate the canonical chunkset.
 watch(
   () => analysisStore.running,
   async (now, prev) => {
@@ -158,7 +160,6 @@ watch(
       const finished = analysisStore.currentAnalysis
       if (finished?.status === 'COMPLETED' && finished.documentId === props.id) {
         await documentStore.reloadWorkspaceAnalyses(props.id)
-        await chunksStore.load(props.id)
       }
     }
   },

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -48,16 +48,20 @@
           >
             ↻ {{ t('history.title') }}
           </button>
-          <!-- + New analysis (#266) — bridges to Studio with this doc
-               pre-selected. Interim until a dedicated launcher ships. -->
+          <!-- + New analysis (#266) — runs the analysis in place. Polls
+               via analysisStore.run; the watcher below refreshes the
+               workspace when status flips to COMPLETED. -->
           <button
             type="button"
             class="header-action-btn header-action-btn--primary"
+            :disabled="analysisStore.running"
             :title="t('newAnalysis.title')"
             data-e2e="new-analysis-btn"
             @click="onNewAnalysis"
           >
-            + {{ t('newAnalysis.title') }}
+            <span v-if="analysisStore.running" class="header-spinner" />
+            <span v-else>+</span>
+            {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
           </button>
         </template>
       </DocWorkspaceHeader>
@@ -94,6 +98,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { RouterLink, useRouter, useRoute } from 'vue-router'
 import type { Document } from '../shared/types'
+import { useAnalysisStore } from '../features/analysis/store'
 import { useChunksStore } from '../features/chunks/store'
 import { fetchDocument } from '../features/document/api'
 import { useDocumentStore } from '../features/document/store'
@@ -118,6 +123,7 @@ const { t } = useI18n()
 const flagStore = useFeatureFlagStore()
 const documentStore = useDocumentStore()
 const chunksStore = useChunksStore()
+const analysisStore = useAnalysisStore()
 
 const historyOpen = ref(false)
 
@@ -131,15 +137,32 @@ async function onSetCurrentAnalysis(analysisId: string): Promise<void> {
 }
 
 /**
- * Bridge to Studio (#266). Until a dedicated "new analysis" screen
- * lands, the doc workspace launches new parses through the existing
- * Studio UI; the docId query param pre-selects the document so the
- * user doesn't have to re-pick it. Studio strips the param from the
- * URL on mount.
+ * In-place analysis launch (#266). Fires `analysisStore.run`, which
+ * POSTs to /api/analyses and starts polling. The watcher below picks
+ * up the COMPLETED transition and refreshes the workspace.
  */
-function onNewAnalysis(): void {
-  router.push({ name: ROUTES.STUDIO, query: { docId: props.id } })
+async function onNewAnalysis(): Promise<void> {
+  if (analysisStore.running) return
+  await analysisStore.run(props.id)
 }
+
+// Watch analysisStore.running: when the in-place launch wraps up and
+// the polling sees a COMPLETED status, refresh the workspace analyses
+// list (the new run shows up in History + becomes the active one) and
+// reload the chunks (the analysis promoter on the backend just wrote
+// the canonical chunkset for the first analysis).
+watch(
+  () => analysisStore.running,
+  async (now, prev) => {
+    if (prev && !now) {
+      const finished = analysisStore.currentAnalysis
+      if (finished?.status === 'COMPLETED' && finished.documentId === props.id) {
+        await documentStore.reloadWorkspaceAnalyses(props.id)
+        await chunksStore.load(props.id)
+      }
+    }
+  },
+)
 
 const doc = ref<Document | null>(null)
 const loadingDoc = ref(true)
@@ -341,10 +364,24 @@ watch(
   color: white;
 }
 
-.header-action-btn--primary:hover {
+.header-action-btn--primary:hover:not(:disabled) {
   filter: brightness(1.1);
   color: white;
   border-color: var(--accent);
+}
+
+.header-action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.header-spinner {
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid rgba(255, 255, 255, 0.4);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
 }
 
 .tab-content {

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -48,6 +48,23 @@
           >
             ↻ {{ t('history.title') }}
           </button>
+          <!-- + Generate chunks (#268, exposed at workspace level after
+               the analysis/chunks decoupling). Visible only on the
+               Chunk view; opens the Strategy popover owned by the
+               chunks store. -->
+          <button
+            v-if="activeMode === 'chunk'"
+            type="button"
+            class="header-action-btn"
+            :disabled="chunksStore.rechunking"
+            :title="t('chunk.panel.generate')"
+            data-e2e="generate-chunks-btn"
+            @click="onGenerateChunks"
+          >
+            <span v-if="chunksStore.rechunking" class="header-spinner" />
+            <span v-else>⚙</span>
+            {{ chunksStore.rechunking ? t('strategy.rechunking') : t('chunk.panel.generate') }}
+          </button>
           <!-- + New analysis (#266) — runs the analysis in place. Polls
                via analysisStore.run; the watcher below refreshes the
                workspace when status flips to COMPLETED. -->
@@ -144,6 +161,11 @@ async function onSetCurrentAnalysis(analysisId: string): Promise<void> {
 async function onNewAnalysis(): Promise<void> {
   if (analysisStore.running) return
   await analysisStore.run(props.id)
+}
+
+/** Open the Strategy popover from the workspace header (#268). */
+function onGenerateChunks(): void {
+  chunksStore.openStrategy()
 }
 
 // Watch analysisStore.running: when the in-place launch wraps up and

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -48,6 +48,17 @@
           >
             ↻ {{ t('history.title') }}
           </button>
+          <!-- + New analysis (#266) — bridges to Studio with this doc
+               pre-selected. Interim until a dedicated launcher ships. -->
+          <button
+            type="button"
+            class="header-action-btn header-action-btn--primary"
+            :title="t('newAnalysis.title')"
+            data-e2e="new-analysis-btn"
+            @click="onNewAnalysis"
+          >
+            + {{ t('newAnalysis.title') }}
+          </button>
         </template>
       </DocWorkspaceHeader>
 
@@ -117,6 +128,17 @@ async function onSetCurrentAnalysis(analysisId: string): Promise<void> {
   // effect of the switch (e.g. a re-promotion) is reflected.
   await chunksStore.load(props.id)
   historyOpen.value = false
+}
+
+/**
+ * Bridge to Studio (#266). Until a dedicated "new analysis" screen
+ * lands, the doc workspace launches new parses through the existing
+ * Studio UI; the docId query param pre-selects the document so the
+ * user doesn't have to re-pick it. Studio strips the param from the
+ * URL on mount.
+ */
+function onNewAnalysis(): void {
+  router.push({ name: ROUTES.STUDIO, query: { docId: props.id } })
 }
 
 const doc = ref<Document | null>(null)
@@ -310,6 +332,18 @@ watch(
 
 .header-action-btn:hover {
   color: var(--accent);
+  border-color: var(--accent);
+}
+
+.header-action-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.header-action-btn--primary:hover {
+  filter: brightness(1.1);
+  color: white;
   border-color: var(--accent);
 }
 

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -17,7 +17,7 @@
       <!-- Sticky header (#218) -->
       <DocWorkspaceHeader :doc="doc">
         <template #actions>
-          <!-- View switcher (#263) — Linked / Inspect / Compare. Compare is
+          <!-- View switcher (#263) — Parse / Chunk / Compare. Compare is
                rendered as a disabled placeholder until #270 (0.9.0). -->
           <div class="view-switcher" role="tablist" data-e2e="view-switcher">
             <button
@@ -38,8 +38,27 @@
               {{ t(`workspace.tabs.${view.key}`) }}
             </button>
           </div>
+          <!-- History drawer trigger (#267) — visible on every view. -->
+          <button
+            type="button"
+            class="header-action-btn"
+            :title="t('history.title')"
+            data-e2e="history-btn"
+            @click="historyOpen = true"
+          >
+            ↻ {{ t('history.title') }}
+          </button>
         </template>
       </DocWorkspaceHeader>
+
+      <!-- History drawer (#267) — teleported to body. -->
+      <HistoryDrawer
+        :open="historyOpen"
+        :analyses="documentStore.workspaceAnalyses"
+        :current-id="documentStore.workspaceCurrentAnalysisId"
+        @close="historyOpen = false"
+        @set-current="onSetCurrentAnalysis"
+      />
 
       <!-- View content — lazy loaded (#216). :key on docId forces a clean
            remount when navigating to a different doc, preventing stale state
@@ -64,7 +83,9 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { RouterLink, useRouter, useRoute } from 'vue-router'
 import type { Document } from '../shared/types'
+import { useChunksStore } from '../features/chunks/store'
 import { fetchDocument } from '../features/document/api'
+import { useDocumentStore } from '../features/document/store'
 import { useFeatureFlagStore } from '../features/feature-flags/store'
 import { type DocMode } from '../shared/routing/modes'
 import { resolveMode } from '../shared/routing/resolveMode'
@@ -74,6 +95,7 @@ import type { Crumb } from '../shared/breadcrumb/types'
 import { useI18n } from '../shared/i18n'
 import { ROUTES } from '../shared/routing/names'
 import DocWorkspaceHeader from '../features/document/ui/DocWorkspaceHeader.vue'
+import HistoryDrawer from '../features/document/ui/HistoryDrawer.vue'
 import DocParseTab from './DocParseTab.vue'
 import DocChunkTab from './DocChunkTab.vue'
 
@@ -83,6 +105,19 @@ const router = useRouter()
 const route = useRoute()
 const { t } = useI18n()
 const flagStore = useFeatureFlagStore()
+const documentStore = useDocumentStore()
+const chunksStore = useChunksStore()
+
+const historyOpen = ref(false)
+
+async function onSetCurrentAnalysis(analysisId: string): Promise<void> {
+  documentStore.setWorkspaceAnalysis(analysisId)
+  // The chunks tied to the canonical chunkset don't change with the
+  // analysis pointer, but reload them anyway so any backend-side side
+  // effect of the switch (e.g. a re-promotion) is reflected.
+  await chunksStore.load(props.id)
+  historyOpen.value = false
+}
 
 const doc = ref<Document | null>(null)
 const loadingDoc = ref(true)
@@ -257,6 +292,25 @@ watch(
 .view-btn.disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.header-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.header-action-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 .tab-content {

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -83,13 +83,14 @@
         </template>
       </DocWorkspaceHeader>
 
-      <!-- History drawer (#267) — teleported to body. -->
+      <!-- History drawer (#267) — teleported to body. Lists frozen
+           (analysis, chunks) versions; "Set as current" restores. -->
       <HistoryDrawer
         :open="historyOpen"
-        :analyses="documentStore.workspaceAnalyses"
-        :current-id="documentStore.workspaceCurrentAnalysisId"
+        :versions="documentStore.workspaceVersions"
+        :current-id="documentStore.workspaceCurrentVersionId"
         @close="historyOpen = false"
-        @set-current="onSetCurrentAnalysis"
+        @set-current="onSetCurrentVersion"
       />
 
       <!-- View content — lazy loaded (#216). :key on docId forces a clean
@@ -144,11 +145,11 @@ const analysisStore = useAnalysisStore()
 
 const historyOpen = ref(false)
 
-async function onSetCurrentAnalysis(analysisId: string): Promise<void> {
-  documentStore.setWorkspaceAnalysis(analysisId)
-  // The chunks tied to the canonical chunkset don't change with the
-  // analysis pointer, but reload them anyway so any backend-side side
-  // effect of the switch (e.g. a re-promotion) is reflected.
+async function onSetCurrentVersion(versionId: string): Promise<void> {
+  const ok = await documentStore.setWorkspaceVersion(versionId)
+  if (!ok) return
+  // The restore endpoint rewrote the live chunkset from the version's
+  // snapshot — reload so Chunk view re-renders with the restored set.
   await chunksStore.load(props.id)
   historyOpen.value = false
 }
@@ -168,21 +169,31 @@ function onGenerateChunks(): void {
   chunksStore.openStrategy()
 }
 
-// Watch analysisStore.running: when the in-place launch wraps up and
-// the polling sees a COMPLETED status, refresh the workspace analyses
-// list (the new run shows up in History + becomes the active one).
-// Chunks are NOT reloaded here — running an analysis no longer creates
-// chunks (the backend auto-promoter was disabled in 0.6.1). The user
-// must explicitly invoke the Strategy popover from the Chunk view to
-// generate / regenerate the canonical chunkset.
+// Watch analysisStore.running: when the in-place launch wraps up,
+// reload the workspace versions list (the backend just appended a
+// fresh ANALYSIS version that becomes the auto-pinned active one).
+// Chunks aren't touched on analysis runs — the version snapshot
+// preserves whatever was there.
 watch(
   () => analysisStore.running,
   async (now, prev) => {
     if (prev && !now) {
       const finished = analysisStore.currentAnalysis
       if (finished?.status === 'COMPLETED' && finished.documentId === props.id) {
-        await documentStore.reloadWorkspaceAnalyses(props.id)
+        await documentStore.reloadWorkspaceVersions(props.id)
       }
+    }
+  },
+)
+
+// Watch chunksStore.rechunking: when `+ Generate chunks` (rechunk)
+// completes, the backend appends a CHUNKS version. Refresh History
+// so the new entry shows up + is pinned.
+watch(
+  () => chunksStore.rechunking,
+  async (now, prev) => {
+    if (prev && !now && documentStore.workspaceDoc?.id === props.id) {
+      await documentStore.reloadWorkspaceVersions(props.id)
     }
   },
 )

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -675,16 +675,6 @@ onMounted(async () => {
     // Clean query param from URL
     router.replace({ query: {} })
   }
-
-  // 0.6.1 (#266) — Bridge from the doc workspace's "+ New analysis"
-  // button: pre-select the document so the user lands ready to launch
-  // a new analysis without picking the file again.
-  const bridgeDocId = route.query.docId
-  if (bridgeDocId && typeof bridgeDocId === 'string') {
-    documentStore.select(bridgeDocId)
-    mode.value = 'configure'
-    router.replace({ query: {} })
-  }
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/pages/StudioPage.vue
+++ b/frontend/src/pages/StudioPage.vue
@@ -675,6 +675,16 @@ onMounted(async () => {
     // Clean query param from URL
     router.replace({ query: {} })
   }
+
+  // 0.6.1 (#266) — Bridge from the doc workspace's "+ New analysis"
+  // button: pre-select the document so the user lands ready to launch
+  // a new analysis without picking the file again.
+  const bridgeDocId = route.query.docId
+  if (bridgeDocId && typeof bridgeDocId === 'string') {
+    documentStore.select(bridgeDocId)
+    mode.value = 'configure'
+    router.replace({ query: {} })
+  }
 })
 
 onBeforeUnmount(() => {

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -435,6 +435,9 @@ const messages: Messages = {
     'chunk.panel.title': 'Chunks',
     'chunk.panel.count': '{n} sur {total} en page {page}',
     'chunk.panel.emptyOnPage': 'Aucun chunk en page {page}.',
+    'chunk.panel.emptyAll':
+      'Aucun chunk pour ce document. Générez-en depuis la stratégie ci-dessous.',
+    'chunk.panel.generate': 'Générer les chunks',
     'chunk.panel.edited': 'modifi\u00e9',
     'chunk.noAnalysis': "Aucune analyse \u2014 lancez d'abord un parse.",
 
@@ -992,6 +995,9 @@ const messages: Messages = {
     'chunk.panel.title': 'Chunks',
     'chunk.panel.count': '{n} of {total} on page {page}',
     'chunk.panel.emptyOnPage': 'No chunks on page {page}.',
+    'chunk.panel.emptyAll':
+      'No chunks for this document yet. Generate them from the strategy below.',
+    'chunk.panel.generate': 'Generate chunks',
     'chunk.panel.edited': 'edited',
     'chunk.noAnalysis': 'No analysis yet — run a parse first.',
 

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -215,8 +215,9 @@ const messages: Messages = {
     'history.setCurrent': 'Sélectionner',
     'history.notCompleted': 'Disponible uniquement pour les analyses terminées.',
     'history.open': 'Ouvrir',
-    // + New analysis bridge to Studio (#266)
+    // + New analysis — in-place trigger (#266)
     'newAnalysis.title': 'Nouvelle analyse',
+    'newAnalysis.running': 'Analyse en cours…',
 
     // Chunking
     'studio.prepare': 'Préparer',
@@ -779,8 +780,9 @@ const messages: Messages = {
     'history.setCurrent': 'Set as current',
     'history.notCompleted': 'Only available for completed analyses.',
     'history.open': 'Open',
-    // + New analysis bridge to Studio (#266)
+    // + New analysis — in-place trigger (#266)
     'newAnalysis.title': 'New analysis',
+    'newAnalysis.running': 'Analyzing…',
 
     'studio.prepare': 'Prepare',
     'studio.ingest': 'Ingest',

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -215,6 +215,8 @@ const messages: Messages = {
     'history.setCurrent': 'Sélectionner',
     'history.notCompleted': 'Disponible uniquement pour les analyses terminées.',
     'history.open': 'Ouvrir',
+    // + New analysis bridge to Studio (#266)
+    'newAnalysis.title': 'Nouvelle analyse',
 
     // Chunking
     'studio.prepare': 'Préparer',
@@ -777,6 +779,8 @@ const messages: Messages = {
     'history.setCurrent': 'Set as current',
     'history.notCompleted': 'Only available for completed analyses.',
     'history.open': 'Open',
+    // + New analysis bridge to Studio (#266)
+    'newAnalysis.title': 'New analysis',
 
     'studio.prepare': 'Prepare',
     'studio.ingest': 'Ingest',

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -212,9 +212,12 @@ const messages: Messages = {
     // for the legacy HistoryPage, same value ("Historique").
     'history.close': 'Fermer',
     'history.current': '— en cours',
-    'history.setCurrent': 'Sélectionner',
+    'history.setCurrent': 'Restaurer',
     'history.notCompleted': 'Disponible uniquement pour les analyses terminées.',
     'history.open': 'Ouvrir',
+    'history.kind.analysis': 'OCR',
+    'history.kind.chunks': 'Chunks',
+    'history.chunksCount': '{n} chunks figés',
     // + New analysis — in-place trigger (#266)
     'newAnalysis.title': 'Nouvelle analyse',
     'newAnalysis.running': 'Analyse en cours…',
@@ -780,9 +783,12 @@ const messages: Messages = {
     // for the legacy HistoryPage, same value ("History").
     'history.close': 'Close',
     'history.current': '— current',
-    'history.setCurrent': 'Set as current',
+    'history.setCurrent': 'Restore',
     'history.notCompleted': 'Only available for completed analyses.',
     'history.open': 'Open',
+    'history.kind.analysis': 'OCR',
+    'history.kind.chunks': 'Chunks',
+    'history.chunksCount': '{n} chunks frozen',
     // + New analysis — in-place trigger (#266)
     'newAnalysis.title': 'New analysis',
     'newAnalysis.running': 'Analyzing…',

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -208,6 +208,12 @@ const messages: Messages = {
     'history.tabDocuments': 'Documents',
     'history.empty': 'Aucune analyse. Analysez votre premier document pour commencer.',
     'history.emptyDocs': 'Aucun document. Importez un document depuis la bibliothèque.',
+    // Workspace history drawer (#267) — `history.title` already declared above
+    // for the legacy HistoryPage, same value ("Historique").
+    'history.close': 'Fermer',
+    'history.current': '— en cours',
+    'history.setCurrent': 'Sélectionner',
+    'history.notCompleted': 'Disponible uniquement pour les analyses terminées.',
     'history.open': 'Ouvrir',
 
     // Chunking
@@ -764,6 +770,12 @@ const messages: Messages = {
     'history.tabDocuments': 'Documents',
     'history.empty': 'No analyses yet. Analyze your first document to get started.',
     'history.emptyDocs': 'No documents yet. Upload a document from the library.',
+    // Workspace history drawer (#267) — `history.title` already declared above
+    // for the legacy HistoryPage, same value ("History").
+    'history.close': 'Close',
+    'history.current': '— current',
+    'history.setCurrent': 'Set as current',
+    'history.notCompleted': 'Only available for completed analyses.',
     'history.open': 'Open',
 
     'studio.prepare': 'Prepare',

--- a/frontend/src/shared/types.ts
+++ b/frontend/src/shared/types.ts
@@ -191,3 +191,21 @@ export interface PushSummary {
   embeds: number
   tokens: number
 }
+
+/**
+ * Frozen pair (#267) — `+ New analysis` and `+ Generate chunks` each
+ * append one of these to the document's History timeline. The drawer
+ * surfaces them; restore replaces the live chunkset with the version's
+ * snapshot.
+ */
+export type DocumentVersionKind = 'analysis' | 'chunks'
+
+export interface DocumentVersion {
+  id: string
+  documentId: string
+  kind: DocumentVersionKind
+  analysisId: string | null
+  chunksSnapshotSize: number
+  summary: string
+  createdAt: string
+}


### PR DESCRIPTION
## Summary

Adds the right-side **History drawer** to the workspace header (T6) and bundles the **"+ New analysis" bridge to Studio** (T5) so the workspace finally has the two missing pieces flagged during the T4 review: a way to switch between past analyses, and a way to launch a new parse from where the absence is visible.

## What changed

### Workspace store — T6

- `workspaceLatestAnalysis` becomes a computed derived from `workspaceAnalyses` + `workspaceCurrentAnalysisId`. Semantically it now means *"the active analysis,"* auto-picked or user-pinned.
- New `workspaceAnalyses` ref carries the full history, sorted newest-first (completedAt, falling back to createdAt for non-completed entries).
- New `workspaceCurrentAnalysisId` ref + `setWorkspaceAnalysis(id)` action.
- `loadWorkspace(docId)` is now **idempotent** — early-returns when the workspace is already loaded for the same doc. This preserves a user-pinned analysis when the user switches between Parse and Chunk tabs (both call `loadWorkspace` on mount).

### History drawer — `features/document/ui/HistoryDrawer.vue` (T6)

- Teleported to body, right-anchored. Backdrop click + close button dismiss.
- One card per analysis: status pill color-coded by `COMPLETED` / `PENDING-RUNNING` / `FAILED`, relative timestamp, full id, `Set as current` action.
- `Set as current` disabled on non-COMPLETED entries (tooltip) — Parse / Chunk can only render a completed analysis's `pages_json`.
- The currently-active analysis gets an `.active` ring + an italic `— current` flag instead of the action button.

### Workspace header buttons — T6 + T5

- New `History` button (T6, secondary): opens the drawer. Visible on every view.
- New `+ New analysis` button (T5, primary): routes to `/studio?docId=<current>` so Studio pre-selects the document and lands in `configure` mode. Interim until a dedicated launcher screen ships.

### Empty-state CTAs — T5

- `DocParseTab` and `DocChunkTab` gain a `+ New analysis` button under the "Aucune analyse" message when no completed analysis exists. Hitting the bridge from where the absence is visible, not just the header.

### StudioPage — T5

- `onMounted` now consumes a `?docId=` query param: pre-selects the document via `documentStore.select` and lands in `configure` mode. Param is stripped from the URL after restore (same pattern as the existing `?analysisId=`).

### E2E

- `doc-history-drawer.feature` — creates two analyses, opens the drawer, verifies the newer one is active by default, sets the older one as current, confirms the active marker moved.

## Test plan

- [x] Frontend: `npm run lint && type-check && test:run` — **343 passed**
- [x] Frontend: prettier clean
- [x] Backend: untouched (endpoint `/api/analyses?documentId=` already exists)
- [x] Manual: open `/docs/<id>` → header shows `History` + `+ New analysis` buttons
- [x] Manual: a doc with no analysis → empty state on Parse and Chunk shows `+ New analysis` CTA
- [x] Manual: click `+ New analysis` → lands on `/studio` with the doc pre-selected, URL is back to `/studio` (no query)
- [x] Manual: a doc with two completed analyses → drawer lists both newest-first, the latest is `— current`
- [x] Manual: `Set as current` on the older → drawer closes, Parse / Chunk re-render against the older analysis
- [x] Manual: switch from Parse to Chunk → pinned analysis survives the view switch (loadWorkspace idempotency)

Closes #267
Closes #266
