### PR TITLE
Workspace tabs UX refresh + pending-push badge on Ingest CTA

### DIFF
--- a/document-parser/services/chunk_service.py
+++ b/document-parser/services/chunk_service.py
@@ -872,35 +872,132 @@ def _compute_chunkset_hash(chunks: list[Chunk]) -> str:
 
 
 def _build_tree_nodes(doc_data: dict) -> list[dict]:
-    """Project a Docling document JSON into a `[DocTreeNode]` outline.
+    """Project a Docling document JSON into a hierarchical `[DocTreeNode]` outline.
 
-    The Docling document layout has top-level lists like `texts`, `tables`,
-    `pictures`, `groups`, etc. Each entry carries a `self_ref` and a
-    `label`. We surface a flat outline grouped by label families, which
-    is enough for the Inspect tab — full hierarchy reconstruction is a
-    follow-up (#216).
+    Two stacking rules combine to follow the document's natural structure:
+
+    1. **Headings nest by level.** `title` opens a level-0 container; each
+       `section_header` opens a container at its declared `level` (default 1).
+       A new heading pops the stack until the top has a strictly lower level,
+       so siblings stay siblings and sub-sections nest inside their parent.
+    2. **Docling parent/child is preserved for containers.** `list` keeps its
+       `list_item` descendants under it; everything else (paragraph, table,
+       picture) is a leaf under the current section.
+
+    Inline-group style runs and picture sub-elements are skipped via the
+    shared `build_collapse_index` helper — keeps the projection in sync
+    with the Neo4j tree writer and the in-memory graph payload.
     """
-    sections = (
-        ("section_header", "Sections", []),
-        ("title", "Titles", []),
-        ("text", "Paragraphs", []),
-        ("table", "Tables", []),
-        ("picture", "Pictures", []),
-    )
-    section_map = {label: bucket for label, _, bucket in sections}
+    from infra.docling_tree import build_collapse_index, iter_items
 
-    for collection in ("texts", "tables", "pictures", "groups"):
-        for item in doc_data.get(collection, []) or []:
-            label = item.get("label") or collection.rstrip("s")
-            ref = item.get("self_ref") or item.get("selfRef") or ""
-            display = item.get("text") or item.get("name") or label
-            bucket = section_map.get(label)
-            if bucket is None:
+    skip_refs, inline_meta = build_collapse_index(doc_data)
+    by_ref: dict[str, dict] = {}
+    for _, item in iter_items(doc_data):
+        ref = item.get("self_ref")
+        if ref:
+            by_ref[ref] = item
+
+    body = doc_data.get("body") or {}
+    root: list[dict] = []
+    # Stack entries: (heading_level, children_list). The sentinel level -1
+    # represents the document root so any heading nests inside it.
+    stack: list[tuple[int, list[dict]]] = [(-1, root)]
+
+    def walk(children: list[dict] | None) -> None:
+        if not children:
+            return
+        for ch in children:
+            ref = ch.get("$ref") or ch.get("cref")
+            if not ref or ref in skip_refs:
                 continue
-            bucket.append({"ref": ref, "type": label, "label": display, "children": []})
+            item = by_ref.get(ref)
+            if item is None:
+                continue
+            label_type = (item.get("label") or "").lower() or "text"
 
-    return [
-        {"ref": f"#group/{key}", "type": "group", "label": title, "children": children}
-        for key, title, children in sections
-        if children
-    ]
+            if label_type in {"title", "section_header"}:
+                level = 0 if label_type == "title" else max(int(item.get("level") or 1), 1)
+                while len(stack) > 1 and stack[-1][0] >= level:
+                    stack.pop()
+                node = _make_node(ref, label_type, item, inline_meta)
+                stack[-1][1].append(node)
+                stack.append((level, node["children"]))
+            else:
+                node = _build_item_subtree(ref, item, by_ref, skip_refs, inline_meta)
+                stack[-1][1].append(node)
+
+    walk(body.get("children"))
+    return root
+
+
+def _build_item_subtree(
+    ref: str,
+    item: dict,
+    by_ref: dict[str, dict],
+    skip_refs: set[str],
+    inline_meta: dict[str, dict],
+) -> dict:
+    """Build a leaf or nested subtree for a non-heading item.
+
+    Containers (list, group, form_area, key_value_area) keep their explicit
+    Docling children so the outline mirrors structures like `list` → `list_item`.
+    Other items are emitted as leaves — pictures and inline groups had their
+    descendants pruned upstream by `build_collapse_index`.
+    """
+    label_type = (item.get("label") or "").lower() or "text"
+    node = _make_node(ref, label_type, item, inline_meta)
+    if label_type in {"list", "group", "form_area", "key_value_area"}:
+        for ch in item.get("children") or []:
+            child_ref = ch.get("$ref") or ch.get("cref")
+            if not child_ref or child_ref in skip_refs:
+                continue
+            child_item = by_ref.get(child_ref)
+            if child_item is None:
+                continue
+            node["children"].append(
+                _build_item_subtree(child_ref, child_item, by_ref, skip_refs, inline_meta)
+            )
+    return node
+
+
+def _make_node(ref: str, label_type: str, item: dict, inline_meta: dict[str, dict]) -> dict:
+    return {
+        "ref": ref,
+        "type": label_type,
+        "label": _display_label(item, inline_meta),
+        "children": [],
+    }
+
+
+def _display_label(item: dict, inline_meta: dict[str, dict]) -> str:
+    """Pick the most human-readable label for the tree node."""
+    from infra.docling_tree import is_inline_group
+
+    ref = item.get("self_ref") or ""
+    label_type = (item.get("label") or "").lower()
+
+    if is_inline_group(item):
+        meta = inline_meta.get(ref)
+        if meta and meta.get("text"):
+            return _truncate(meta["text"])
+
+    text = (item.get("text") or "").strip()
+    if text:
+        return _truncate(text)
+
+    if label_type == "table":
+        return "Table"
+    if label_type == "picture":
+        return "Figure"
+    if label_type == "list":
+        return "List"
+    if label_type == "group":
+        return (item.get("name") or "Group").strip()
+    return label_type or "node"
+
+
+def _truncate(text: str, max_len: int = 80) -> str:
+    text = text.strip()
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1].rstrip() + "…"

--- a/document-parser/tests/test_chunk_service.py
+++ b/document-parser/tests/test_chunk_service.py
@@ -761,14 +761,95 @@ class TestGetTree:
     async def test_tree_empty_when_no_analysis(self, service, doc):
         assert await service.get_tree(doc.id) == []
 
-    async def test_tree_groups_by_label(self, service, repos, doc):
+    async def test_tree_follows_document_hierarchy(self, service, repos, doc):
+        """Title → H1 → H2 nest by heading level, leaves under their section."""
         job = AnalysisJob(document_id=doc.id, status=AnalysisStatus.COMPLETED)
         await repos["analyses"].insert(job)
         job.document_json = json.dumps(
             {
+                "body": {
+                    "self_ref": "#/body",
+                    "children": [
+                        {"$ref": "#/texts/0"},
+                        {"$ref": "#/texts/1"},
+                        {"$ref": "#/texts/2"},
+                        {"$ref": "#/texts/3"},
+                        {"$ref": "#/texts/4"},
+                        {"$ref": "#/texts/5"},
+                    ],
+                },
                 "texts": [
-                    {"self_ref": "#/texts/0", "label": "title", "text": "Hi"},
-                    {"self_ref": "#/texts/1", "label": "text", "text": "Body"},
+                    {"self_ref": "#/texts/0", "label": "title", "text": "Doc Title"},
+                    {
+                        "self_ref": "#/texts/1",
+                        "label": "section_header",
+                        "text": "Chapter 1",
+                        "level": 1,
+                    },
+                    {"self_ref": "#/texts/2", "label": "text", "text": "Intro paragraph"},
+                    {
+                        "self_ref": "#/texts/3",
+                        "label": "section_header",
+                        "text": "Section 1.1",
+                        "level": 2,
+                    },
+                    {"self_ref": "#/texts/4", "label": "text", "text": "Nested paragraph"},
+                    {
+                        "self_ref": "#/texts/5",
+                        "label": "section_header",
+                        "text": "Chapter 2",
+                        "level": 1,
+                    },
+                ],
+                "tables": [],
+                "pictures": [],
+                "groups": [],
+            }
+        )
+        job.completed_at = datetime.now(UTC)
+        await repos["analyses"].update_status(job)
+        tree = await service.get_tree(doc.id)
+
+        # Single top-level title containing both chapters.
+        assert len(tree) == 1
+        title = tree[0]
+        assert title["type"] == "title"
+        assert title["label"] == "Doc Title"
+        assert [c["label"] for c in title["children"]] == ["Chapter 1", "Chapter 2"]
+
+        chapter1 = title["children"][0]
+        # Intro paragraph then Section 1.1 (which owns the nested paragraph).
+        assert [c["type"] for c in chapter1["children"]] == ["text", "section_header"]
+        section_1_1 = chapter1["children"][1]
+        assert [c["label"] for c in section_1_1["children"]] == ["Nested paragraph"]
+
+        # Chapter 2 is a sibling, not a child of Section 1.1.
+        chapter2 = title["children"][1]
+        assert chapter2["children"] == []
+
+    async def test_tree_keeps_list_items_under_list(self, service, repos, doc):
+        """`list` containers preserve their `list_item` descendants."""
+        job = AnalysisJob(document_id=doc.id, status=AnalysisStatus.COMPLETED)
+        await repos["analyses"].insert(job)
+        job.document_json = json.dumps(
+            {
+                "body": {
+                    "self_ref": "#/body",
+                    "children": [{"$ref": "#/groups/0"}],
+                },
+                "groups": [
+                    {
+                        "self_ref": "#/groups/0",
+                        "label": "list",
+                        "children": [
+                            {"$ref": "#/texts/0"},
+                            {"$ref": "#/texts/1"},
+                        ],
+                    }
+                ],
+                "texts": [
+                    {"self_ref": "#/texts/0", "label": "list_item", "text": "First"},
+                    {"self_ref": "#/texts/1", "label": "list_item", "text": "Second"},
                 ],
                 "tables": [],
                 "pictures": [],
@@ -777,9 +858,8 @@ class TestGetTree:
         job.completed_at = datetime.now(UTC)
         await repos["analyses"].update_status(job)
         tree = await service.get_tree(doc.id)
-        labels = {n["type"] for n in tree}
-        assert labels == {"group"}
-        # Both Titles and Paragraphs groups should be present
-        group_titles = {n["label"] for n in tree}
-        assert "Titles" in group_titles
-        assert "Paragraphs" in group_titles
+
+        assert len(tree) == 1
+        list_node = tree[0]
+        assert list_node["type"] == "list"
+        assert [c["label"] for c in list_node["children"]] == ["First", "Second"]

--- a/frontend/src/features/chunks/ui/ChunksPanel.vue
+++ b/frontend/src/features/chunks/ui/ChunksPanel.vue
@@ -1,26 +1,16 @@
 <template>
   <section class="chunks-panel" data-e2e="chunks-panel">
     <header class="chunks-panel-header">
-      <h2 class="chunks-panel-title">{{ t('linked.chunks.title') }}</h2>
+      <h2 class="chunks-panel-title">{{ t('chunk.panel.title') }}</h2>
       <span class="chunks-panel-count">
         {{
-          t('linked.chunks.count', {
+          t('chunk.panel.count', {
             n: pageChunks.length,
             total: chunksStore.chunks.length,
             page: currentPage,
           })
         }}
       </span>
-      <button
-        type="button"
-        class="strategy-btn"
-        :disabled="chunksStore.rechunking"
-        :title="t('chunk.strategy')"
-        data-e2e="strategy-btn"
-        @click="chunksStore.openStrategy"
-      >
-        ⚙ {{ t('chunk.strategy') }}
-      </button>
     </header>
 
     <StrategyPopover
@@ -75,7 +65,7 @@
           </span>
           <span class="chunk-seq">#{{ chunk.sequence }}</span>
           <span v-if="chunk.sourcePage !== null" class="chunk-page">p.{{ chunk.sourcePage }}</span>
-          <span v-if="isEdited(chunk)" class="edited-badge">{{ t('linked.chunks.edited') }}</span>
+          <span v-if="isEdited(chunk)" class="edited-badge">{{ t('chunk.panel.edited') }}</span>
           <span v-if="chunk.tokenCount" class="chunk-tokens">{{ chunk.tokenCount }}t</span>
         </div>
         <div class="chunk-card-body">
@@ -97,8 +87,9 @@
  * until #91 / #92 / #95 refactor them — by design we ship the Linked
  * view with a minimal read-only-ish surface.
  *
- * The Strategy button is rendered as disabled with a tooltip until
- * T7 (#268) wires the rechunk popover.
+ * The Strategy popover trigger moved to the Chunk tab's top toolbar
+ * (LayersBar action slot); this panel still owns the popover render
+ * and apply handler since rechunk lives on the chunks store.
  */
 import { computed, watch } from 'vue'
 import type { DocChunk } from '../../../shared/types'
@@ -207,27 +198,6 @@ void props.docId
   color: var(--text-muted);
   font-family: 'IBM Plex Mono', monospace;
   margin-right: auto;
-}
-
-.strategy-btn {
-  font-size: 11px;
-  padding: 3px 10px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: all var(--transition);
-}
-
-.strategy-btn:hover:not(:disabled) {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
-.strategy-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .chunks-panel-state {

--- a/frontend/src/features/document/ui/DocTreeNode.vue
+++ b/frontend/src/features/document/ui/DocTreeNode.vue
@@ -32,6 +32,7 @@
         :depth="depth + 1"
         :selected="selected"
         :highlight="highlight"
+        :default-open="defaultOpen"
         @select="$emit('select', $event)"
       />
     </ul>
@@ -49,15 +50,17 @@ const props = withDefaults(
     depth?: number
     selected?: string | null
     highlight?: string | null
+    /** When set, every node mounts in that state (used by Expand/Collapse-all). */
+    defaultOpen?: boolean | null
   }>(),
-  { depth: 0 },
+  { depth: 0, defaultOpen: null },
 )
 
 const emit = defineEmits<{
   select: [ref: string]
 }>()
 
-const open = ref(props.depth < 2)
+const open = ref(props.defaultOpen ?? props.depth < 3)
 
 const hasChildren = computed(() => props.node.children.length > 0)
 

--- a/frontend/src/features/document/ui/DocTreeRail.vue
+++ b/frontend/src/features/document/ui/DocTreeRail.vue
@@ -17,6 +17,7 @@
         :node="node"
         :selected="selected"
         :highlight="highlight"
+        :default-open="defaultOpen"
         @select="(ref) => $emit('select', ref)"
       />
     </ul>
@@ -34,6 +35,8 @@ defineProps<{
   error?: string | null
   selected?: string | null
   highlight?: string | null
+  /** Forwarded to every node — null lets each node use its depth-based default. */
+  defaultOpen?: boolean | null
 }>()
 
 defineEmits<{

--- a/frontend/src/features/document/ui/LayersBar.vue
+++ b/frontend/src/features/document/ui/LayersBar.vue
@@ -16,39 +16,34 @@
         <span class="chip-count">{{ entry.count }}</span>
       </button>
     </div>
-    <label class="show-labels-toggle" data-e2e="show-labels-toggle">
-      <input type="checkbox" :checked="showLabels" @change="onToggleLabels" />
-      <span>{{ t('linked.showLabels') }}</span>
-    </label>
+    <div class="layers-action">
+      <slot name="action" />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 /**
- * LAYERS chip row + "Show labels" toggle (#264).
+ * LAYERS chip row (#264).
  *
- * Externally controlled via v-model on `hiddenTypes` and `showLabels`.
+ * Externally controlled via v-model on `hiddenTypes`.
  * Renders chips in `LAYER_ORDER`, then appends any extra types found on
  * the page (in insertion order) so the bar never silently swallows a new
- * element kind.
+ * element kind. An optional `action` slot is right-aligned for the
+ * tab-level primary CTA.
  */
 import { computed } from 'vue'
 import type { PageElement } from '../../../shared/types'
-import { useI18n } from '../../../shared/i18n'
 import { colorFor, LAYER_ORDER } from '../elementColors'
 
 const props = defineProps<{
   elements: readonly PageElement[]
   hiddenTypes: ReadonlySet<string>
-  showLabels: boolean
 }>()
 
 const emit = defineEmits<{
   'update:hiddenTypes': [next: Set<string>]
-  'update:showLabels': [next: boolean]
 }>()
-
-const { t } = useI18n()
 
 const chipEntries = computed(() => {
   const counts = new Map<string, number>()
@@ -68,10 +63,6 @@ function toggle(type: string): void {
   if (next.has(type)) next.delete(type)
   else next.add(type)
   emit('update:hiddenTypes', next)
-}
-
-function onToggleLabels(e: Event): void {
-  emit('update:showLabels', (e.target as HTMLInputElement).checked)
 }
 </script>
 
@@ -135,13 +126,9 @@ function onToggleLabels(e: Event): void {
   font-size: 10px;
 }
 
-.show-labels-toggle {
+.layers-action {
+  margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  margin-left: auto;
-  font-size: 12px;
-  color: var(--text-secondary);
-  cursor: pointer;
 }
 </style>

--- a/frontend/src/features/document/ui/PagePreviewWithOverlay.vue
+++ b/frontend/src/features/document/ui/PagePreviewWithOverlay.vue
@@ -14,6 +14,30 @@
       <span class="page-paginator-meta">
         {{ t('workspace.pageOf', { page: currentPage, total: totalPages }) }}
       </span>
+      <div class="page-paginator-nav">
+        <button
+          type="button"
+          class="page-nav-btn"
+          :disabled="currentPage <= 1"
+          :title="t('workspace.pagePrev')"
+          :aria-label="t('workspace.pagePrev')"
+          data-e2e="page-prev"
+          @click="onPageChange(currentPage - 1)"
+        >
+          ‹
+        </button>
+        <button
+          type="button"
+          class="page-nav-btn"
+          :disabled="currentPage >= totalPages"
+          :title="t('workspace.pageNext')"
+          :aria-label="t('workspace.pageNext')"
+          data-e2e="page-next"
+          @click="onPageChange(currentPage + 1)"
+        >
+          ›
+        </button>
+      </div>
     </div>
     <div class="preview-stage" ref="stageRef">
       <div class="preview-frame" ref="frameRef">
@@ -201,6 +225,36 @@ watch(
   font-size: 11px;
   color: var(--text-muted);
   font-family: 'IBM Plex Mono', monospace;
+}
+
+.page-paginator-nav {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 4px;
+}
+
+.page-nav-btn {
+  min-width: 24px;
+  padding: 2px 8px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.page-nav-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.page-nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .preview-stage {

--- a/frontend/src/pages/DocChunkTab.vue
+++ b/frontend/src/pages/DocChunkTab.vue
@@ -3,10 +3,23 @@
     <LayersBar
       :elements="currentPageElements"
       :hidden-types="hiddenTypes"
-      :show-labels="showLabels"
       @update:hidden-types="(next) => (hiddenTypes = next)"
-      @update:show-labels="(next) => (showLabels = next)"
-    />
+    >
+      <template #action>
+        <button
+          type="button"
+          class="tab-action-cta"
+          :disabled="chunksStore.rechunking"
+          :title="t('chunk.panel.generate')"
+          data-e2e="chunk-generate-btn"
+          @click="onGenerateChunks"
+        >
+          <span v-if="chunksStore.rechunking" class="tab-action-spinner" />
+          <span v-else>⚙</span>
+          {{ chunksStore.rechunking ? t('strategy.rechunking') : t('chunk.panel.generate') }}
+        </button>
+      </template>
+    </LayersBar>
     <div class="chunk-body">
       <div class="chunk-stage">
         <PagePreviewWithOverlay
@@ -15,7 +28,7 @@
           :pages="documentStore.workspacePages"
           :current-page="currentPage"
           :hidden-types="hiddenTypes"
-          :show-labels="showLabels"
+          :show-labels="true"
           :highlighted-refs="highlightedRefs"
           @update:current-page="(p) => (currentPage = p)"
           @hover-element="onHoverElement"
@@ -26,17 +39,6 @@
         </div>
         <div v-else class="chunk-state chunk-state--empty">
           <p>{{ t('chunk.noAnalysis') }}</p>
-          <button
-            type="button"
-            class="chunk-state-cta"
-            :disabled="analysisStore.running"
-            data-e2e="chunk-empty-cta"
-            @click="onLaunchAnalysis"
-          >
-            <span v-if="analysisStore.running" class="cta-spinner" />
-            <span v-else>+</span>
-            {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
-          </button>
         </div>
       </div>
       <aside class="chunk-aside">
@@ -72,7 +74,6 @@
  */
 import { computed, onMounted, ref, watch } from 'vue'
 import type { DocStoreLink, PageElement } from '../shared/types'
-import { useAnalysisStore } from '../features/analysis/store'
 import { useChunksStore } from '../features/chunks/store'
 import { useDocumentStore } from '../features/document/store'
 import { chunkForElement, elementRefsForChunk } from '../features/document/linkedView'
@@ -90,16 +91,13 @@ const props = defineProps<{
 const { t } = useI18n()
 const documentStore = useDocumentStore()
 const chunksStore = useChunksStore()
-const analysisStore = useAnalysisStore()
 
-async function onLaunchAnalysis(): Promise<void> {
-  if (analysisStore.running) return
-  await analysisStore.run(props.docId)
+function onGenerateChunks(): void {
+  chunksStore.openStrategy()
 }
 
 const currentPage = ref(1)
 const hiddenTypes = ref<Set<string>>(new Set())
-const showLabels = ref(false)
 const hoveredChunkId = ref<string | null>(null)
 const selectedChunkId = ref<string | null>(null)
 
@@ -187,7 +185,7 @@ watch(
   gap: 12px;
 }
 
-.chunk-state-cta {
+.tab-action-cta {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -201,16 +199,16 @@ watch(
   transition: filter var(--transition);
 }
 
-.chunk-state-cta:hover:not(:disabled) {
+.tab-action-cta:hover:not(:disabled) {
   filter: brightness(1.1);
 }
 
-.chunk-state-cta:disabled {
+.tab-action-cta:disabled {
   opacity: 0.7;
   cursor: not-allowed;
 }
 
-.cta-spinner {
+.tab-action-spinner {
   width: 10px;
   height: 10px;
   border: 1.5px solid rgba(255, 255, 255, 0.4);

--- a/frontend/src/pages/DocIngestTab.vue
+++ b/frontend/src/pages/DocIngestTab.vue
@@ -10,7 +10,14 @@
         @click="onLaunchClick"
       >
         <span class="ingest-launch-icon">↑</span>
-        {{ t('ingest.launchCta') }}
+        {{ t('ingest.launchCta')
+        }}<span
+          v-if="pendingPushCount > 0"
+          class="ingest-launch-badge"
+          data-e2e="ingest-launch-badge"
+        >
+          {{ pendingPushCount }}
+        </span>
       </button>
     </header>
 
@@ -126,7 +133,7 @@ import { formatAbsolute, formatRelativeTime } from '../shared/format'
 import { useI18n } from '../shared/i18n'
 import { ROUTES } from '../shared/routing/names'
 import IngestLaunchDialog from './IngestLaunchDialog.vue'
-import { type HistoryDisplayEntry, toHistoryEntry } from './DocIngestTab.logic'
+import { type HistoryDisplayEntry, buildRows, toHistoryEntry } from './DocIngestTab.logic'
 
 const props = defineProps<{
   docId: string
@@ -152,6 +159,15 @@ const dialogOpen = ref(false)
 
 const hasStores = computed(() => stores.value.length > 0)
 const hasMore = computed(() => history.value.length < total.value)
+
+// Pending-push hint on the CTA: count of connected stores that are
+// Stale or NotPushed — same set the launch modal pre-checks. Surfaces
+// at-a-glance "there's work to do" without forcing the user to open
+// the modal first.
+const pendingPushCount = computed(() => {
+  const rows = buildRows(stores.value, props.storeLinks)
+  return rows.filter((r) => r.connected && (r.state === 'Stale' || r.state === 'NotPushed')).length
+})
 
 async function load(): Promise<void> {
   loading.value = true
@@ -254,6 +270,23 @@ onMounted(load)
 
 .ingest-launch-icon {
   font-size: 14px;
+}
+
+.ingest-launch-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  margin-left: 8px;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'IBM Plex Mono', monospace;
+  letter-spacing: 0.02em;
 }
 
 .ingest-state {

--- a/frontend/src/pages/DocParseTab.vue
+++ b/frontend/src/pages/DocParseTab.vue
@@ -3,10 +3,23 @@
     <LayersBar
       :elements="currentPageElements"
       :hidden-types="hiddenTypes"
-      :show-labels="showLabels"
       @update:hidden-types="(next) => (hiddenTypes = next)"
-      @update:show-labels="(next) => (showLabels = next)"
-    />
+    >
+      <template #action>
+        <button
+          type="button"
+          class="tab-action-cta"
+          :disabled="analysisStore.running"
+          :title="t('newAnalysis.title')"
+          data-e2e="parse-new-analysis"
+          @click="onLaunchAnalysis"
+        >
+          <span v-if="analysisStore.running" class="tab-action-spinner" />
+          <span v-else>+</span>
+          {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
+        </button>
+      </template>
+    </LayersBar>
     <div class="parse-body">
       <aside class="parse-structure">
         <header class="parse-structure-header">
@@ -14,6 +27,28 @@
           <span class="parse-structure-count">
             {{ t('parse.structureNodes', { n: nodeCount }) }}
           </span>
+          <div class="parse-structure-actions">
+            <button
+              type="button"
+              class="tree-action-btn"
+              :title="t('parse.expandAll')"
+              :aria-label="t('parse.expandAll')"
+              data-e2e="tree-expand-all"
+              @click="onExpandAll"
+            >
+              ⊕
+            </button>
+            <button
+              type="button"
+              class="tree-action-btn"
+              :title="t('parse.collapseAll')"
+              :aria-label="t('parse.collapseAll')"
+              data-e2e="tree-collapse-all"
+              @click="onCollapseAll"
+            >
+              ⊖
+            </button>
+          </div>
         </header>
         <input
           v-model="filter"
@@ -23,11 +58,13 @@
           data-e2e="structure-filter"
         />
         <DocTreeRail
+          :key="treeRemountKey"
           :nodes="filteredNodes"
           :loading="treeLoading"
           :error="treeError"
           :selected="selectedNodeRef"
           :highlight="selectedNodeRef"
+          :default-open="treeDefaultOpen"
           @select="onTreeSelect"
           @reload="loadTree"
         />
@@ -39,7 +76,7 @@
           :pages="documentStore.workspacePages"
           :current-page="currentPage"
           :hidden-types="hiddenTypes"
-          :show-labels="showLabels"
+          :show-labels="true"
           :highlighted-refs="highlightedRefs"
           @update:current-page="(p) => (currentPage = p)"
           @hover-element="onHoverElement"
@@ -50,17 +87,6 @@
         </div>
         <div v-else class="parse-state parse-state--empty">
           <p>{{ t('parse.noAnalysis') }}</p>
-          <button
-            type="button"
-            class="parse-state-cta"
-            :disabled="analysisStore.running"
-            data-e2e="parse-empty-cta"
-            @click="onLaunchAnalysis"
-          >
-            <span v-if="analysisStore.running" class="cta-spinner" />
-            <span v-else>+</span>
-            {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
-          </button>
         </div>
       </div>
       <ElementProperties
@@ -115,7 +141,19 @@ async function onLaunchAnalysis(): Promise<void> {
 
 const currentPage = ref(1)
 const hiddenTypes = ref<Set<string>>(new Set())
-const showLabels = ref(false)
+
+// Expand/Collapse all — bumping `treeRemountKey` re-keys the rail so every
+// DocTreeNode mounts fresh and picks up the new `treeDefaultOpen` value.
+const treeRemountKey = ref(0)
+const treeDefaultOpen = ref<boolean | null>(null)
+function onExpandAll(): void {
+  treeDefaultOpen.value = true
+  treeRemountKey.value++
+}
+function onCollapseAll(): void {
+  treeDefaultOpen.value = false
+  treeRemountKey.value++
+}
 
 const tree = ref<DocTreeNode[]>([])
 const treeLoading = ref(false)
@@ -310,6 +348,33 @@ function findPageOfRef(
   font-family: 'IBM Plex Mono', monospace;
 }
 
+.parse-structure-actions {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 4px;
+}
+
+.tree-action-btn {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  line-height: 1;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.tree-action-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .parse-structure-filter {
   margin: 8px 14px;
   padding: 6px 10px;
@@ -342,7 +407,7 @@ function findPageOfRef(
   gap: 12px;
 }
 
-.parse-state-cta {
+.tab-action-cta {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -356,16 +421,16 @@ function findPageOfRef(
   transition: filter var(--transition);
 }
 
-.parse-state-cta:hover:not(:disabled) {
+.tab-action-cta:hover:not(:disabled) {
   filter: brightness(1.1);
 }
 
-.parse-state-cta:disabled {
+.tab-action-cta:disabled {
   opacity: 0.7;
   cursor: not-allowed;
 }
 
-.cta-spinner {
+.tab-action-spinner {
   width: 10px;
   height: 10px;
   border: 1.5px solid rgba(255, 255, 255, 0.4);

--- a/frontend/src/pages/DocWorkspacePage.vue
+++ b/frontend/src/pages/DocWorkspacePage.vue
@@ -48,38 +48,6 @@
           >
             ↻ {{ t('history.title') }}
           </button>
-          <!-- + Generate chunks (#268, exposed at workspace level after
-               the analysis/chunks decoupling). Visible only on the
-               Chunk view; opens the Strategy popover owned by the
-               chunks store. -->
-          <button
-            v-if="activeMode === 'chunk'"
-            type="button"
-            class="header-action-btn"
-            :disabled="chunksStore.rechunking"
-            :title="t('chunk.panel.generate')"
-            data-e2e="generate-chunks-btn"
-            @click="onGenerateChunks"
-          >
-            <span v-if="chunksStore.rechunking" class="header-spinner" />
-            <span v-else>⚙</span>
-            {{ chunksStore.rechunking ? t('strategy.rechunking') : t('chunk.panel.generate') }}
-          </button>
-          <!-- + New analysis (#266) — runs the analysis in place. Polls
-               via analysisStore.run; the watcher below refreshes the
-               workspace when status flips to COMPLETED. -->
-          <button
-            type="button"
-            class="header-action-btn header-action-btn--primary"
-            :disabled="analysisStore.running"
-            :title="t('newAnalysis.title')"
-            data-e2e="new-analysis-btn"
-            @click="onNewAnalysis"
-          >
-            <span v-if="analysisStore.running" class="header-spinner" />
-            <span v-else>+</span>
-            {{ analysisStore.running ? t('newAnalysis.running') : t('newAnalysis.title') }}
-          </button>
         </template>
       </DocWorkspaceHeader>
 
@@ -160,21 +128,6 @@ async function onSetCurrentVersion(versionId: string): Promise<void> {
   // snapshot — reload so Chunk view re-renders with the restored set.
   await chunksStore.load(props.id)
   historyOpen.value = false
-}
-
-/**
- * In-place analysis launch (#266). Fires `analysisStore.run`, which
- * POSTs to /api/analyses and starts polling. The watcher below picks
- * up the COMPLETED transition and refreshes the workspace.
- */
-async function onNewAnalysis(): Promise<void> {
-  if (analysisStore.running) return
-  await analysisStore.run(props.id)
-}
-
-/** Open the Strategy popover from the workspace header (#268). */
-function onGenerateChunks(): void {
-  chunksStore.openStrategy()
 }
 
 // Watch analysisStore.running: when the in-place launch wraps up,

--- a/frontend/src/shared/i18n.ts
+++ b/frontend/src/shared/i18n.ts
@@ -407,7 +407,6 @@ const messages: Messages = {
 
     // Parse view (#264) \u2014 Docling extraction graph
     'parse.layers': 'LAYERS',
-    'parse.showLabels': 'Afficher les libell\u00e9s',
     // Element Properties panel (#265)
     'properties.title': 'Propri\u00e9t\u00e9s',
     'properties.empty':
@@ -428,13 +427,16 @@ const messages: Messages = {
     'properties.save': 'Enregistrer',
     'properties.saving': 'Enregistrement\u2026',
     'workspace.pageOf': 'Page {page} sur {total}',
+    'workspace.pagePrev': 'Page précédente',
+    'workspace.pageNext': 'Page suivante',
     'parse.structureTitle': 'Structure',
     'parse.structureNodes': '{n} n\u0153uds',
     'parse.filterPlaceholder': 'Filtrer les \u00e9l\u00e9ments\u2026',
     'parse.noAnalysis': "Aucune analyse \u2014 lancez d'abord un parse.",
+    'parse.expandAll': 'Tout d\u00e9plier',
+    'parse.collapseAll': 'Tout replier',
 
     // Chunk view (#264) \u2014 chunks aligned to the page preview
-    'chunk.showLabels': 'Afficher les libell\u00e9s',
     'chunk.strategy': 'Strat\u00e9gie',
     'chunk.panel.title': 'Chunks',
     'chunk.panel.count': '{n} sur {total} en page {page}',
@@ -1033,7 +1035,6 @@ const messages: Messages = {
 
     // Parse view (#264) — Docling extraction graph
     'parse.layers': 'LAYERS',
-    'parse.showLabels': 'Show labels',
     // Element Properties panel (#265)
     'properties.title': 'Properties',
     'properties.empty': 'Select a node in the tree or click a bbox.',
@@ -1053,13 +1054,16 @@ const messages: Messages = {
     'properties.save': 'Save',
     'properties.saving': 'Saving…',
     'workspace.pageOf': 'Page {page} of {total}',
+    'workspace.pagePrev': 'Previous page',
+    'workspace.pageNext': 'Next page',
     'parse.structureTitle': 'Structure',
     'parse.structureNodes': '{n} nodes',
     'parse.filterPlaceholder': 'Filter elements…',
     'parse.noAnalysis': 'No analysis yet — run a parse first.',
+    'parse.expandAll': 'Expand all',
+    'parse.collapseAll': 'Collapse all',
 
     // Chunk view (#264) — chunks aligned to the page preview
-    'chunk.showLabels': 'Show labels',
     'chunk.strategy': 'Strategy',
     'chunk.panel.title': 'Chunks',
     'chunk.panel.count': '{n} of {total} on page {page}',


### PR DESCRIPTION
## Type

- [x] Feature (`feature/*`)
- [ ] Bug fix (`fix/*`)
- [ ] Hotfix (`hotfix/*`)
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other: ___

## Summary

Stabilizes the doc workspace banner across Parse / Chunk / Ingest tabs, gives each tab a consistent top-right CTA (`+ New analysis`, `⚙ Generate chunks`), rebuilds the Parse Structure rail as a real document-following hierarchy with Expand-/Collapse-all controls, adds prev/next page arrows, and adds a pending-push badge on the existing Ingest launch CTA.

> **Scope adjustment after rebase**: this PR originally also reintroduced a push-history endpoint + Ingest tab redesign. That work landed concurrently on `release/0.6.1` via #283 (PR #284) with a more polished design (paginated history, `IngestLaunchDialog`, `storeDeleted` tag). The duplicate commit was dropped and only the unique value-add — the pending-push count badge on the launch CTA — kept on top of #283's foundation.

## Related issues

Closes #285

## Checklist

- [x] Branch follows naming convention (`feature/`, `fix/`, `hotfix/`)
- [x] Commits follow [Conventional Commits](docs/git-workflow/commit-conventions.md)
- [x] Tests added/updated for the change
- [x] All tests pass (`pytest tests/ -v` + `npm run test:run`)
- [x] Linting passes (`ruff check .` + `npx eslint src/`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Documentation updated if behavior changed
- [x] No secrets or credentials committed

## What's in this PR

**Workspace UX cleanup** (commit `d36cea8`)

- Banner is now identical on Parse / Chunk / Ingest — only `↻ History` stays.
- Per-tab top-right CTAs share one CSS class: Parse `+ New analysis`, Chunk `⚙ Generate chunks`.
- LayersBar: Show-labels toggle dropped (labels always on), `action` slot exposed.
- Page paginator: `‹` / `›` prev/next arrows on the right, disabled at edges.
- Parse Structure rail: replaced the flat group-by-type projection with a real heading-level hierarchy via `infra.docling_tree.build_collapse_index`. Expand-all / Collapse-all controls re-mount every node with the new default.
- `ChunksPanel.vue`: i18n key fix (`linked.chunks.*` → existing `chunk.panel.*`).

**Ingest CTA enhancement** (commit `454f0d7`)

- `↑ Launch ingest` button now carries a small badge with the count of connected stores that are Stale or NotPushed (same set the dialog pre-checks). Saves a click for the most common "what needs ingesting?" question.

## Validation

```
Backend: ruff check ✓, ruff format --check ✓, 732 pytest passed + 15 skipped
Frontend: eslint ✓, prettier ✓, vue-tsc ✓, 398 vitest passed (38 test files)
```