### PR TITLE
fix(docker): wire dev frontend proxy target

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,11 @@ services:
       - neo4j_data:/data
       - neo4j_logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u $${NEO4J_USER:-neo4j} -p $${NEO4J_PASSWORD:-changeme} 'RETURN 1' || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "cypher-shell -u $${NEO4J_USER:-neo4j} -p $${NEO4J_PASSWORD:-changeme} 'RETURN 1' || exit 1",
+        ]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -41,7 +45,11 @@ services:
     volumes:
       - opensearch_data:/usr/share/opensearch/data
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:9200/_cluster/health || exit 1",
+        ]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -100,7 +108,8 @@ services:
       NEO4J_URI: bolt://neo4j:7687
       NEO4J_USER: ${NEO4J_USER:-neo4j}
       NEO4J_PASSWORD: ${NEO4J_PASSWORD:-changeme}
-    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+    command:
+      ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     depends_on:
       opensearch:
         condition: service_healthy
@@ -124,6 +133,7 @@ services:
       - frontend_node_modules:/app/node_modules
     environment:
       VITE_APP_VERSION: dev
+      VITE_API_PROXY_TARGET: http://document-parser:8000
     command: ["sh", "-c", "npm install && npm run dev -- --host"]
     depends_on:
       - document-parser

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,7 @@ import vue from '@vitejs/plugin-vue'
 import { readFileSync } from 'fs'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000'
 
 export default defineConfig({
   plugins: [vue()],
@@ -13,13 +14,13 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true
+        target: apiProxyTarget,
+        changeOrigin: true,
       },
       '/health': {
-        target: 'http://localhost:8000',
-        changeOrigin: true
-      }
-    }
-  }
+        target: apiProxyTarget,
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Type

- [ ] Feature (`feature/*`)
- [x] Bug fix (`fix/*`)
- [ ] Hotfix (`hotfix/*`)
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/CD
- [ ] Other: ___

## Summary

- Set `VITE_API_PROXY_TARGET` in `docker-compose.dev.yml` so the frontend dev container proxies API requests to the `document-parser` service on the compose network.
- Keep the PR focused to the dev compose wiring needed for the local development stack.

## Related issues

- None

## Checklist

- [x] Branch follows naming convention (`feature/`, `fix/`, `hotfix/`)
- [x] Commits follow [Conventional Commits](docs/git-workflow/commit-conventions.md)
- [ ] Tests added/updated for the change
- [ ] All tests pass (`pytest tests/ -v` + `npm run test:run`)
- [ ] Linting passes (`ruff check .` + `npx eslint src/`)
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Documentation updated if behavior changed
- [x] No secrets or credentials committed

## Screenshots / Evidence

- `docker-compose.dev.yml` now exports `VITE_API_PROXY_TARGET=http://document-parser:8000` for the frontend service.