### PR TITLE
ci(e2e-ui): opt in STUDIO_MODE_ENABLED on main CI too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,10 @@ jobs:
         timeout-minutes: 10
         env:
           RATE_LIMIT_RPM: "0"
+          # The @critical UI suite still drives the legacy /studio surface
+          # (#257 made it default-off). Enable it for e2e until those tests
+          # are rewritten against /docs/:id in 0.7.0. Mirrors release-gate.yml.
+          STUDIO_MODE_ENABLED: "true"
 
       - name: Wait for health
         run: |


### PR DESCRIPTION
## Type

- [x] CI/CD

## Summary

Mirror the `STUDIO_MODE_ENABLED=true` env var already set in `release-gate.yml` (commit 65ea145) onto the identical `e2e-ui` job in `ci.yml`. Without it, every push-to-main run times out on the 4 @critical UI tests because `/studio` redirects to `/docs` when the flag is off, so `[data-e2e=doc-item]` never renders and `waitFor` hits the 120s limit on each test (~28min job failure — [run 26442079217](https://github.com/scub-france/docling-Studio/actions/runs/26442079217)).

Same scope as 65ea145 — test infrastructure only, no production behaviour change.

## Related issues

Refs #257 (which made `STUDIO_MODE_ENABLED` default-off).
Follow-up tracked for 0.7.0: rewrite the four legacy `/studio` tests against `/docs/:id` and drop the flag entirely.

## Checklist

- [x] Branch follows naming convention (`fix/ci-studio-mode-enabled-e2e-ui`)
- [x] Commits follow Conventional Commits
- [x] No tests required — workflow-only change
- [x] No secrets or credentials committed

## Screenshots / Evidence

Local verification with the flag wired exactly as the patched workflow does:

```
$ STUDIO_MODE_ENABLED=true RATE_LIMIT_RPM=0 docker compose up -d --wait --build
$ mvn test -f e2e/ui/pom.xml \
    -DbaseUrl=http://localhost:3000 \
    -DuiBaseUrl=http://localhost:3000 \
    -Dkarate.options="--tags @critical"

Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS — Total time: 01:59 min
```

The 4 tests that timed out in CI (`analyses/batch-progress`, `analyses/rechunk`, `documents/delete`, `analyses/analysis`) all pass with the flag set.