### PR TITLE
chore(dev): add pre-push validation hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,10 @@ jobs:
 
       - name: Run E2E tests
         run: |
+          BASE_REF="${{ github.base_ref }}"
+          REF_NAME="${{ github.ref }}"
           KARATE_TAGS="@smoke"
-          if [[ "${{ github.base_ref }}" == release/* ]] || [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+          if [[ "$BASE_REF" == release/* ]] || [[ "$REF_NAME" == refs/heads/release/* ]]; then
             KARATE_TAGS="@smoke,@regression,@e2e"
           fi
           mvn test -f e2e/api/pom.xml -DbaseUrl=http://localhost:3000 -Dkarate.options="--tags ${KARATE_TAGS}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
           - --exclude-files
           - ^(frontend/package-lock\.json|document-parser/uv\.lock|embedding-service/uv\.lock)$
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.(yml|yaml)$
+
   - repo: local
     hooks:
       - id: block-local-generated-artifacts
@@ -39,6 +45,17 @@ repos:
         stages:
           - commit-msg
         always_run: true
+      - id: lockfile-consistency
+        name: lockfile consistency
+        entry: bash ./scripts/check_lockfile_consistency.sh
+        language: system
+        files: ^(frontend/package(-lock)?\.json|document-parser/(pyproject\.toml|uv\.lock)|embedding-service/(pyproject\.toml|uv\.lock))$
+      - id: docker-compose-validate
+        name: docker compose validate
+        entry: bash ./scripts/check_docker_compose.sh
+        language: system
+        files: ^docker-compose.*\.yml$
+        pass_filenames: false
       - id: document-parser-ruff-check
         name: document-parser ruff check --fix
         entry: uv run --directory document-parser ruff check --fix .
@@ -102,4 +119,21 @@ repos:
         stages:
           - pre-push
         files: ^frontend/src/.*\.(ts|vue)$
+        pass_filenames: false
+      - id: document-parser-full-tests
+        name: document-parser full tests
+        entry: uv run --directory document-parser pytest tests/ -q
+        language: system
+        stages:
+          - pre-push
+        files: ^document-parser/.*\.py$
+        exclude: ^document-parser/local-experiments/
+        pass_filenames: false
+      - id: frontend-build
+        name: frontend build
+        entry: npm --prefix frontend run build
+        language: system
+        stages:
+          - pre-push
+        files: ^frontend/(src/.*\.(css|js|ts|vue)|package(-lock)?\.json|tsconfig.*\.json|vite\.config\..*)$
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ npm run dev
 
 ### Git hooks (recommended)
 
-The repository ships with a root `.pre-commit-config.yaml` that auto-fixes Python and frontend files before each commit, runs targeted backend/frontend tests, blocks local/generated artifacts, scans for likely secrets, enforces Conventional Commit messages, runs `document-parser/tests/test_architecture.py` when backend layers change, then runs a frontend type-check before each push.
+The repository ships with a root `.pre-commit-config.yaml` that auto-fixes Python and frontend files before each commit, runs targeted backend/frontend tests, blocks local/generated artifacts, scans for likely secrets, validates lockfile updates and workflow/compose changes, enforces Conventional Commit messages, runs `document-parser/tests/test_architecture.py` when backend layers change, then runs a frontend type-check, frontend build, and full `document-parser` test suite before each push when those areas changed.
 
 ```bash
 bash ./scripts/initial_setup.sh

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ bash ./scripts/initial_setup.sh
 ```
 
 The script installs frontend dependencies, syncs the Python dev environments used by the hooks, installs `pre-commit`, and wires the repo's `pre-commit` / `pre-push` / `commit-msg` hooks.
-On commit, the hooks auto-fix Ruff and frontend formatting issues, run targeted backend/frontend tests, block local/generated artifacts, scan for likely secrets, enforce Conventional Commit messages, and run the `document-parser` architecture tests when backend layers change.
+On commit, the hooks auto-fix Ruff and frontend formatting issues, run targeted backend/frontend tests, block local/generated artifacts, scan for likely secrets, validate lockfile updates and workflow/compose changes, enforce Conventional Commit messages, and run the `document-parser` architecture tests when backend layers change.
+On push, the hooks also run the full `document-parser` test suite and the frontend build when those areas changed.
 On pull requests, CI also enforces `80%` coverage on changed backend lines only.
 
 **Backend** (Python 3.12+):

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -51,7 +51,7 @@ On pull requests, CI enforces `80%` coverage on changed backend lines only.
 
 ### Git hooks
 
-The repository ships with a root `.pre-commit-config.yaml` that auto-fixes Python and frontend files before each commit, runs targeted backend/frontend tests, blocks local/generated artifacts, scans for likely secrets, enforces Conventional Commit messages, runs `document-parser/tests/test_architecture.py` when backend layers change, then runs a frontend type-check before each push.
+The repository ships with a root `.pre-commit-config.yaml` that auto-fixes Python and frontend files before each commit, runs targeted backend/frontend tests, blocks local/generated artifacts, scans for likely secrets, validates lockfile updates and workflow/compose changes, enforces Conventional Commit messages, runs `document-parser/tests/test_architecture.py` when backend layers change, then runs a frontend type-check, frontend build, and full `document-parser` test suite before each push when those areas changed.
 
 ```bash
 bash ./scripts/initial_setup.sh

--- a/scripts/check_docker_compose.sh
+++ b/scripts/check_docker_compose.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+docker compose -f docker-compose.dev.yml config -q
+docker compose --profile ingestion -f docker-compose.yml -f docker-compose.ingestion.yml config -q

--- a/scripts/check_lockfile_consistency.sh
+++ b/scripts/check_lockfile_consistency.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+require_pair() {
+  local manifest="$1"
+  local lockfile="$2"
+  shift 2
+
+  local manifest_changed=0
+  local lockfile_changed=0
+  local path
+
+  for path in "$@"; do
+    if [ "$path" = "$manifest" ]; then
+      manifest_changed=1
+    fi
+    if [ "$path" = "$lockfile" ]; then
+      lockfile_changed=1
+    fi
+  done
+
+  if [ "$manifest_changed" -eq 1 ] && [ "$lockfile_changed" -eq 0 ]; then
+    printf 'Lockfile mismatch: %s changed without %s\n' "$manifest" "$lockfile" >&2
+    exit 1
+  fi
+}
+
+require_pair frontend/package.json frontend/package-lock.json "$@"
+require_pair document-parser/pyproject.toml document-parser/uv.lock "$@"
+require_pair embedding-service/pyproject.toml embedding-service/uv.lock "$@"


### PR DESCRIPTION
## Summary
- add pre-push validation for docker compose and dependency lockfile changes
- extend local docs to cover the added push-time validation
- tighten the CI workflow expectations mirrored locally

## Testing
- pre-commit hooks
- frontend type-check
- frontend build