### PR TITLE
ci(docling-compat): fix version-capture quoting in canary

### DIFF
--- a/.github/workflows/docling-compat.yml
+++ b/.github/workflows/docling-compat.yml
@@ -42,8 +42,8 @@ jobs:
         id: versions
         run: |
           uv pip install --python .venv/bin/python --upgrade docling docling-core
-          echo "docling=$(uv run python -c 'import importlib.metadata as m; print(m.version("'"'docling"'"'))')" >> "$GITHUB_OUTPUT"
-          echo "docling_core=$(uv run python -c 'import importlib.metadata as m; print(m.version("'"'docling-core"'"'))')" >> "$GITHUB_OUTPUT"
+          echo "docling=$(uv run python -c 'import importlib.metadata as m; print(m.version("docling"))')" >> "$GITHUB_OUTPUT"
+          echo "docling_core=$(uv run python -c 'import importlib.metadata as m; print(m.version("docling-core"))')" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
         run: uv run pytest tests/ -v


### PR DESCRIPTION
## What

The scheduled **Docling compatibility** canary ([run 29993874669](https://github.com/scub-france/docling-Studio/actions/runs/29993874669)) fails silently. Two upstream-skew test errors are expected canary output, but the workflow can't even report them:

- The *Upgrade docling to latest* step's nested quoting produced `print(m.version("'docling"` — an unclosed paren + stray quote → `SyntaxError`, so the `docling` / `docling_core` step outputs were never set.
- The *Open issue on failure* github-script then errored on the empty interpolation (`Unexpected token ')'`), so **no compat issue was opened**.

## Fix

Double quotes inside the single-quoted `python -c` argument are sufficient; drop the convoluted escaping.

```diff
-echo "docling=$(uv run python -c 'import importlib.metadata as m; print(m.version("'"'docling"'"'))')" >> "$GITHUB_OUTPUT"
+echo "docling=$(uv run python -c 'import importlib.metadata as m; print(m.version("docling"))')" >> "$GITHUB_OUTPUT"
```

## Notes / out of scope

The underlying test failures (`ImportError: cannot import name 'Orientation'`) originate **inside docling itself** — the latest `docling` imports `Orientation` from a `docling-core` version that no longer exports it. That's a transient upstream packaging skew; our pinned versions are unaffected and there's no production impact. This PR only makes the canary report such breaks correctly.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` and confirm the version outputs populate and (given the current upstream skew) a `docling-compat` issue is opened.