### PR TITLE
fix(release): ship the reasoning stack in the published local image (0.7.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,16 @@ jobs:
           # operators rebuilding from source) default to BAKE_MODELS=false
           # to keep the project HF-free outside this one sanctioned path.
           # See docs/architecture/huggingface-dependency-map.md.
+          # WITH_REASONING ships docling-agent + mellea inside the published
+          # `local` image. Without it the reasoning stack is absent and
+          # POST /api/documents/{id}/reasoning 503s, so the Ask surface and the
+          # trace timeline are unreachable from the image users actually pull —
+          # the runtime panel (#317) can toggle the feature, but it cannot
+          # install the packages. Only the `local` stage declares this ARG.
           build-args: |
             APP_VERSION=${{ steps.version.outputs.value }}
             BAKE_MODELS=${{ matrix.target == 'local' && 'true' || 'false' }}
+            WITH_REASONING=${{ matrix.target == 'local' && 'true' || 'false' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.target }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **The published `local` image now ships the reasoning stack** (`release.yml`): the release build never passed `WITH_REASONING`, so `docling-agent` + `mellea` were absent from `ghcr.io/scub-france/docling-studio:0.7.0-local` and `POST /api/documents/{id}/reasoning` answered `503` — the 0.7.0 headline feature was unreachable from the image users pull. The runtime panel (#317) can toggle reasoning, but it cannot install packages. `release.yml` now passes `WITH_REASONING=true` on the `local` target; the lightweight `remote` image is unchanged (its stage does not declare the ARG), and source builds stay opt-in.
+- **README reasoning section corrected**: it still described the v1 graph overlay that 0.7.0 removed, and still called the stack "disabled by default". It now documents the Parse-view timeline, the published-image behaviour, and the two upstream limits (docling-agent 0.6.0 emits only `READ` steps and reports no per-step timing).
+
+### Known gap
+
+- The release gate has **no reasoning coverage at all** — no workflow builds a `WITH_REASONING` image and `release-gate.yml` contains no reasoning job, so a fully green gate says nothing about this feature. The `e2e-ui-reasoning` job specified in `docs/design/303-reasoning-trace-v2-parse-view.md` was never created. Tracked as follow-up.
+
 ## [0.7.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-24
+
 ### Fixed
 
 - **The published `local` image now ships the reasoning stack** (`release.yml`): the release build never passed `WITH_REASONING`, so `docling-agent` + `mellea` were absent from `ghcr.io/scub-france/docling-studio:0.7.0-local` and `POST /api/documents/{id}/reasoning` answered `503` — the 0.7.0 headline feature was unreachable from the image users pull. The runtime panel (#317) can toggle reasoning, but it cannot install packages. `release.yml` now passes `WITH_REASONING=true` on the `local` target; the lightweight `remote` image is unchanged (its stage does not declare the ARG), and source builds stay opt-in.

--- a/README.md
+++ b/README.md
@@ -308,11 +308,17 @@ RETURN d.title, t.caption, t.cells_json
 
 The in-app **Graph** tab (under *Results*) renders the per-document graph with [Cytoscape.js](https://js.cytoscape.org/) (see [ADR-001](docs/architecture/adrs/ADR-001-graph-visualization-library.md) for the library choice). Documents with more than **200 pages** return `HTTP 413` from `GET /api/documents/{id}/graph`; pagination ships in v0.6.
 
-## Live Reasoning (opt-in, R&D)
+## Live Reasoning (R&D)
 
-Docling Studio can run [docling-agent](https://github.com/docling-project/docling-agent)'s Chunkless RAG loop against an analyzed document and return a full **reasoning trace** — the path the agent walked through the document outline, with the section reference / rationale / answer for each iteration. The trace is overlaid on the document graph so you can *see* how the agent navigated the structure.
+Docling Studio can run [docling-agent](https://github.com/docling-project/docling-agent)'s Chunkless RAG loop against an analyzed document and return a full **reasoning trace**. Since 0.7.0 (#303) the trace renders as a step timeline in the **Parse view of an analysis** (*Analyses* → open a run), next to an **Ask** panel: focusing a step reveals and scrolls the cited element across the PDF preview, the document tree and the Parse view. The standalone `/reasoning` page and its graph overlay were removed — the old routes redirect.
 
-Disabled by default — pulls heavy deps (`docling-agent`, `mellea`, ~60 MB) and needs a reachable Ollama instance with the target model already pulled.
+Two caveats about what the timeline shows today, both upstream: docling-agent 0.6.0's chunkless loop emits only `READ` steps (the other kinds — `PLAN`/`RETRIEVE`/`RERANK`/`VERIFY`/`ANSWER`/`MAP` — are reserved in the wire contract), and it reports no per-step duration, so the timeline renders in its uniform "step-order" mode with a footnote instead of inventing bars. The run's wall-clock total is captured server-side and is real.
+
+Needs a reachable Ollama instance with the target model already pulled. The published `local` image ships the reasoning packages (`docling-agent`, `mellea`); the lightweight `remote` image does not. Building from source keeps them opt-in:
+
+```bash
+docker build --build-arg WITH_REASONING=true --target local -t docling-studio:reasoning .
+```
 
 ### Enable
 
@@ -324,7 +330,7 @@ export REASONING_MODEL_ID=gpt-oss:20b           # any model already pulled in Ol
 export LLM_PROVIDER_TYPE=ollama
 ```
 
-Then `uv sync --group dev --group local` (or use the `local` Docker image which bundles the local stack) and restart the backend. The frontend reads `reasoningAvailable` from `/api/health` and hides the **Reasoning** sidebar entry when the runner isn't wired — so users never click through to a 503.
+For a source checkout, `uv sync --group dev --group local --group reasoning`, then restart the backend. The frontend reads `reasoningAvailable` from `/api/health` and hides the Ask surface when the runner isn't wired — so users never click through to a 503. `REASONING_ENABLED` can also be flipped at runtime from `/settings` (see below) without a restart, but only if the packages are present in the image.
 
 ### Runtime configuration (#317)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docling-studio",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Type

- [x] Hotfix (`hotfix/*`)

## Summary

**0.7.0's headline feature is not in the image people pull.** `release.yml` never passed `WITH_REASONING`, so `docling-agent` + `mellea` were excluded from `ghcr.io/scub-france/docling-studio:0.7.0-local`, `POST /api/documents/{id}/reasoning` answers `503`, and the Ask panel / trace timeline are unreachable. The #317 runtime panel can *toggle* reasoning, but it cannot *install* packages.

This ships 0.7.1 as a packaging fix.

## What changed

- **`release.yml`** passes `WITH_REASONING=true` on the `local` target. Only that target: the `remote` stage is `FROM base` + `ENV CONVERSION_ENGINE=remote` and does not declare the ARG, so passing it there would be a silent no-op — and the lightweight remote image (~270 MB) is a deliberate design choice. Builds from source keep the opt-in default.
- **README** — the *Live Reasoning* section still described the v1 graph overlay that 0.7.0 removed, and still called the stack "disabled by default". It now documents the Parse-view timeline, the published-image behaviour, and two upstream limits that were never written down: docling-agent 0.6.0 emits only `READ` steps (the other kinds are reserved wire-contract values) and reports no per-step duration, so the timeline renders in "step-order" mode by design rather than as a fallback.
- **CHANGELOG** — `[0.7.1]` section, plus an explicit *Known gap* entry (below).
- **Version** bumped to `0.7.1`.

## ⚠️ Known gap this exposes

The release gate has **no reasoning coverage at all**: no workflow builds a `WITH_REASONING` image, and `release-gate.yml` contains zero reasoning jobs. A fully green 13/13 gate says nothing about this feature — which is exactly how 0.7.0 shipped without it. The `e2e-ui-reasoning` job specified in `docs/design/303-reasoning-trace-v2-parse-view.md` (goal list, "new `e2e-ui-reasoning` CI job (`WITH_REASONING` image, `@reasoning-on` tag) green") was never created.

Recorded in the CHANGELOG as a follow-up rather than quietly carried. Worth landing before the next release that touches reasoning.

## Risks

- **New CVE surface.** Adding `docling-agent` + `mellea` (and their transitive LLM SDK weight) to the scanned `local` image may surface new Trivy findings. `.trivyignore.yaml` already carries 7 suppressions; watch the `Security scan — local` job on this PR.
- **Image size grows.** The `local` image was ~1.85 GB. The `Image size check` job is non-blocking but will report the delta.

## Related issues

Follows the 0.7.0 release (#321). No linked issue — found while drafting the release announcement.

## Checklist

- [x] Branch follows naming convention (`hotfix/*`, cut from `main`)
- [x] Commits follow Conventional Commits
- [ ] Tests added/updated — n/a, CI packaging change; the real gap (a reasoning e2e job) is called out above rather than faked
- [x] All tests pass — to be confirmed by the gate on this PR
- [x] Linting passes
- [x] `CHANGELOG.md` updated — `[0.7.1]` section frozen with date
- [x] Documentation updated — README reasoning section corrected
- [x] No secrets or credentials committed

## Evidence

Before (`release.yml`): `build-args` = `APP_VERSION`, `BAKE_MODELS`. `Dockerfile:88` = `ARG WITH_REASONING=false`. `document-parser/pyproject.toml:44-50` keeps `docling-agent==0.6.0` / `mellea==0.4.2` in `[dependency-groups] reasoning`, and `Dockerfile:100-104` only syncs that group when the flag is `true` — hence `503` on the published image.
